### PR TITLE
[YS-162] 공고 등록 시 사진 추가 구현

### DIFF
--- a/src/app/upload/components/DescriptionSection/DescriptionSection.tsx
+++ b/src/app/upload/components/DescriptionSection/DescriptionSection.tsx
@@ -260,8 +260,8 @@ const photoContainer = css`
 
 const deleteButton = css`
   position: absolute;
-  top: 0.55rem;
-  right: 0.55rem;
+  top: 0.4rem;
+  right: 0.4rem;
   border: none;
   border-radius: 50%;
 `;

--- a/src/app/upload/components/DescriptionSection/DescriptionSection.tsx
+++ b/src/app/upload/components/DescriptionSection/DescriptionSection.tsx
@@ -1,10 +1,44 @@
 import { css, Theme } from '@emotion/react';
+import Image from 'next/image';
+import { useState, ChangeEvent } from 'react';
 
 import { headingIcon, input } from '../UploadContainer/UploadContainer';
 
 import Icon from '@/components/Icon';
+import { colors } from '@/styles/colors';
+
+type Photo = {
+  id: string;
+  src: string;
+  file: File;
+};
 
 const DescriptionSection = () => {
+  const [photos, setPhotos] = useState<Photo[]>([]);
+  const MAX_PHOTOS = 3;
+
+  const uploadPhotos = (e: ChangeEvent<HTMLInputElement>): void => {
+    const files = e.target.files;
+    if (files) {
+      const newPhotos = Array.from(files).map((file) => ({
+        id: URL.createObjectURL(file),
+        src: URL.createObjectURL(file),
+        file,
+      }));
+
+      if (photos.length + newPhotos.length > MAX_PHOTOS) {
+        const allowedPhotos = newPhotos.slice(0, MAX_PHOTOS - photos.length);
+        setPhotos((prevPhotos) => [...prevPhotos, ...allowedPhotos]);
+      } else {
+        setPhotos((prevPhotos) => [...prevPhotos, ...newPhotos]);
+      }
+    }
+  };
+
+  const deletePhoto = (id: string): void => {
+    setPhotos((prevPhotos) => prevPhotos.filter((photo) => photo.id !== id));
+  };
+
   return (
     <div css={descriptionLayout}>
       <h3>
@@ -23,14 +57,49 @@ const DescriptionSection = () => {
           <textarea
             name="description"
             id="description"
-            css={descriptionTextarea}
+            css={descriptionTextarea(photos.length > 0 ? 8.5 : 0)}
             placeholder="본문을 입력해 주세요"
           />
+          {photos.length > 0 && (
+            <div css={photoGrid}>
+              {photos.map((photo) => (
+                <div css={photoWrapper} key={photo.id}>
+                  <div css={photoContainer}>
+                    <button css={deleteButton} onClick={() => deletePhoto(photo.id)}>
+                      <Icon
+                        icon="CloseRound"
+                        width={20}
+                        height={20}
+                        color={colors.field09}
+                        cursor="pointer"
+                        subcolor={colors.field01}
+                      />
+                    </button>
+                    <Image
+                      src={photo.src}
+                      alt="업로드한 이미지 미리보기"
+                      width={80}
+                      height={80}
+                      style={{ objectFit: 'cover', borderRadius: '1.2rem' }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
           <div css={uploadImagesContainer}>
-            <button type="button" css={addImageContainer}>
+            <label htmlFor="photos" css={addImageContainer}>
               <Icon icon="ImageAdd" width={16} height={16} />
               <p>사진 추가</p>
-            </button>
+            </label>
+            <input
+              type="file"
+              id="photos"
+              accept="image/*"
+              multiple
+              onChange={uploadPhotos}
+              style={{ display: 'none' }}
+            />
             <p>jpg, png 최대 3장까지 첨부할 수 있어요</p>
           </div>
         </div>
@@ -56,43 +125,43 @@ export const fullInput = css`
   max-width: 93.6rem;
 `;
 
-const descriptionContentContainer = (theme: Theme) => css`
-  width: 93.6rem;
-  height: 27.6rem;
+const descriptionContentContainer = (theme: Theme) =>
+  css`
+    width: 93.6rem;
+    border: 0.1rem solid ${theme.colors.line01};
 
-  border: 0.1rem solid ${theme.colors.line01};
-  border-radius: 1.2rem;
+    border-radius: 1.2rem;
 
-  :focus-within {
-    border: 0.1rem solid ${theme.colors.lineTinted};
+    :focus-within {
+      border: 0.1rem solid ${theme.colors.lineTinted};
 
-    > div:last-of-type {
-      border: none;
+      > div:last-of-type {
+        border-bottom: 0.1rem solid ${theme.colors.line01};
+      }
     }
-  }
-`;
+  `;
 
-const descriptionTextarea = (theme: Theme) => css`
-  ${theme.fonts.label.large.R14};
+const descriptionTextarea = (photoGridHeight: number) => (theme: Theme) =>
+  css`
+    ${theme.fonts.label.large.R14};
 
-  border: none;
-  border-bottom: 0.1rem solid ${theme.colors.line01};
-  border-top-left-radius: 1.2rem;
-  border-top-right-radius: 1.2rem;
+    border: none;
+    border-top-left-radius: 1.2rem;
+    border-top-right-radius: 1.2rem;
 
-  width: 100%;
-  height: 22rem;
+    width: 100%;
+    height: calc(22rem - ${photoGridHeight}rem);
 
-  outline: none;
+    outline: none;
 
-  padding: 1.4rem 1.6rem;
+    padding: 1.4rem 1.6rem;
 
-  resize: none;
+    resize: none;
 
-  &::placeholder {
-    color: ${theme.colors.text02};
-  }
-`;
+    &::placeholder {
+      color: ${theme.colors.text02};
+    }
+  `;
 
 const uploadImagesContainer = (theme: Theme) => css`
   height: 5.6rem;
@@ -103,6 +172,8 @@ const uploadImagesContainer = (theme: Theme) => css`
   gap: 1.2rem;
 
   padding: 1.2rem 1.6rem;
+
+  border-top: 0.1rem solid ${theme.colors.line01};
 
   p {
     ${theme.fonts.label.large.R14};
@@ -126,4 +197,42 @@ const addImageContainer = (theme: Theme) => css`
   padding: 0.8rem 1.2rem;
 
   border-radius: 0.8rem;
+  cursor: pointer;
+`;
+
+const photoGrid = css`
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  padding: 0 1.6rem;
+  height: 8rem;
+
+  margin-top: 1rem;
+  margin-bottom: 1.4rem;
+`;
+
+const photoWrapper = css`
+  width: 8rem;
+  height: 8rem;
+
+  border-radius: 4px;
+  background: white;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const photoContainer = css`
+  position: relative;
+  width: 8rem;
+  height: 8rem;
+`;
+
+const deleteButton = css`
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  border: none;
+  border-radius: 50%;
 `;

--- a/src/app/upload/components/DescriptionSection/DescriptionSection.tsx
+++ b/src/app/upload/components/DescriptionSection/DescriptionSection.tsx
@@ -39,6 +39,28 @@ const DescriptionSection = () => {
     setPhotos((prevPhotos) => prevPhotos.filter((photo) => photo.id !== id));
   };
 
+  const onDragStart = (e: React.DragEvent<HTMLDivElement>, index: number): void => {
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('photoIndex', String(index));
+  };
+
+  const onDragOver = (e: React.DragEvent<HTMLDivElement>): void => {
+    e.preventDefault();
+  };
+
+  const onDrop = (e: React.DragEvent<HTMLDivElement>, targetIndex: number): void => {
+    e.preventDefault();
+    const sourceIndex = Number(e.dataTransfer.getData('photoIndex'));
+
+    if (sourceIndex === targetIndex) return;
+
+    const updatedPhotos = [...photos];
+    const [movedPhoto] = updatedPhotos.splice(sourceIndex, 1);
+    updatedPhotos.splice(targetIndex, 0, movedPhoto);
+
+    setPhotos(updatedPhotos);
+  };
+
   return (
     <div css={descriptionLayout}>
       <h3>
@@ -62,8 +84,15 @@ const DescriptionSection = () => {
           />
           {photos.length > 0 && (
             <div css={photoGrid}>
-              {photos.map((photo) => (
-                <div css={photoWrapper} key={photo.id}>
+              {photos.map((photo, index) => (
+                <div
+                  css={photoLayout}
+                  key={photo.id}
+                  draggable
+                  onDragStart={(e) => onDragStart(e, index)}
+                  onDragOver={onDragOver}
+                  onDrop={(e) => onDrop(e, index)}
+                >
                   <div css={photoContainer}>
                     <button css={deleteButton} onClick={() => deletePhoto(photo.id)}>
                       <Icon
@@ -211,7 +240,7 @@ const photoGrid = css`
   margin-bottom: 1.4rem;
 `;
 
-const photoWrapper = css`
+const photoLayout = css`
   width: 8rem;
   height: 8rem;
 

--- a/src/components/Icon/icons/CloseRound.tsx
+++ b/src/components/Icon/icons/CloseRound.tsx
@@ -1,8 +1,8 @@
-import { SVGProps } from 'react';
+import { CustomSVGProps } from '..';
 
 import theme from '@/styles/theme';
 
-function CloseRound(props: SVGProps<SVGSVGElement>) {
+function CloseRound(props: CustomSVGProps) {
   return (
     <svg
       width="24"
@@ -18,6 +18,10 @@ function CloseRound(props: SVGProps<SVGSVGElement>) {
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"
+      />
+      <path
+        d="M15.36 15.36C15.65 15.07 15.65 14.59 15.36 14.3L13.06 12L15.36 9.69998C15.65 9.40998 15.65 8.92999 15.36 8.63999C15.07 8.34999 14.59 8.34999 14.3 8.63999L12 10.94L9.69998 8.63999C9.40998 8.34999 8.92999 8.34999 8.63999 8.63999C8.34999 8.92999 8.34999 9.40998 8.63999 9.69998L10.94 12L8.63999 14.3C8.34999 14.59 8.34999 15.07 8.63999 15.36C8.78999 15.51 8.97999 15.58 9.16999 15.58C9.35999 15.58 9.54998 15.51 9.69998 15.36L12 13.06L14.3 15.36C14.45 15.51 14.64 15.58 14.83 15.58C15.02 15.58 15.21 15.51 15.36 15.36Z"
+        fill={props.subcolor || theme.colors.field01}
       />
     </svg>
   );


### PR DESCRIPTION
## Issue Number

close #16 

<!-- #이슈번호 -->

## As-Is

사진 추가 X

<!-- 문제 상황 정의 -->

## To-Be
- 사진 추가 (파일 업로드)
- 최대 3장 개수 제한 (그 이상 선택했을 시 선택한 순서대로 3장만)
- 사진 미리보기
- 미리보기 사진 삭제
- 미리보기 순서 드래그앤 드랍으로 변경

<!-- 변경 사항 -->

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="774" alt="image" src="https://github.com/user-attachments/assets/17e8811f-10cf-4cad-8eae-977b6dd0d59f" />


## (Optional) Additional Description

사진 추가 및 미리보기 드래그앤 드랍을 구현하였습니다.
이전 PR과 마찬가지로 시연을 위해 빠르게 작업하다보니 컴포넌트, 파일 분리는 아직 하지 않았습니다.
해당 리뷰도 리팩토링 pr 때 부탁드리겠습니다! 🙇‍♂️



