### PR TITLE
[FEAT] next build 오류 해결 및 github actions CI 스크립트 작성

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI for FE
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build

--- a/src/app/join/components/Participant/JoinInfoStep/AreaTooltip/AreaTooltip.tsx
+++ b/src/app/join/components/Participant/JoinInfoStep/AreaTooltip/AreaTooltip.tsx
@@ -1,7 +1,8 @@
 import * as Tooltip from '@radix-ui/react-tooltip';
 
-import Icon from '@/components/Icon';
 import { tooltipArrow, tooltipContent } from './AreaTooltip.styles';
+
+import Icon from '@/components/Icon';
 
 const AreaTooltip = () => {
   return (

--- a/src/app/join/components/Participant/JoinInfoStep/JoinInfoStep.tsx
+++ b/src/app/join/components/Participant/JoinInfoStep/JoinInfoStep.tsx
@@ -1,5 +1,6 @@
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 
+import AreaTooltip from './AreaTooltip/AreaTooltip';
 import {
   filterTitle,
   filterTitleWrapper,
@@ -17,7 +18,6 @@ import { JOIN_REGION, JOIN_SUB_REGION } from '@/app/join/JoinPage.constants';
 import { joinForm } from '@/app/join/JoinPage.styles';
 import { Gender, MatchType } from '@/app/join/JoinPage.types';
 import { ParticipantJoinSchemaType } from '@/schema/join/ParticipantJoinSchema';
-import AreaTooltip from './AreaTooltip/AreaTooltip';
 
 interface JoinInfoStepProps {
   handleSubmit: () => void;

--- a/src/app/join/components/Participant/ParticipantForm.tsx
+++ b/src/app/join/components/Participant/ParticipantForm.tsx
@@ -4,6 +4,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import useFunnel from '../../hooks/useFunnel';
 import useParticipantJoinMutation from '../../hooks/useParticipantJoinMutation';
+import { STEP } from '../../JoinPage.constants';
 import { getProvider } from '../../JoinPage.utils';
 import JoinSuccessStep from '../JoinSuccessStep/JoinSuccessStep';
 
@@ -13,7 +14,6 @@ import useSessionStorage from '@/hooks/useSessionStorage';
 import ParticipantJoinSchema, {
   ParticipantJoinSchemaType,
 } from '@/schema/join/ParticipantJoinSchema';
-import { STEP } from '../../JoinPage.constants';
 
 const ParticipantForm = () => {
   const oauthEmail = useSessionStorage('email');

--- a/src/app/join/components/Researcher/ResearcherForm.tsx
+++ b/src/app/join/components/Researcher/ResearcherForm.tsx
@@ -4,6 +4,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import useFunnel from '../../hooks/useFunnel';
 import useResearcherJoinMutation from '../../hooks/useResearcherJoinMutation';
+import { STEP } from '../../JoinPage.constants';
 import { getProvider } from '../../JoinPage.utils';
 import JoinSuccessStep from '../JoinSuccessStep/JoinSuccessStep';
 
@@ -11,7 +12,6 @@ import { Researcher } from '.';
 
 import useSessionStorage from '@/hooks/useSessionStorage';
 import ResearcherJoinSchema, { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
-import { STEP } from '../../JoinPage.constants';
 
 const ResearcherForm = () => {
   const oauthEmail = useSessionStorage('email');

--- a/src/app/join/hooks/useFunnel.tsx
+++ b/src/app/join/hooks/useFunnel.tsx
@@ -31,23 +31,25 @@ const useFunnel = <Steps extends StepsType>(steps: Steps) => {
     }
   };
 
-  const Funnel = useMemo(
-    () =>
-      ({ children }: FunnelProps) => {
-        const targetStep = children.find((childStep) => childStep.props.name === currentStep);
+  const Funnel = useMemo(() => {
+    const FunnelComponent = ({ children }: FunnelProps) => {
+      const targetStep = children.find((childStep) => childStep.props.name === currentStep);
 
-        return <>{targetStep}</>;
-      },
+      return <>{targetStep}</>;
+    };
 
-    [currentStep],
-  );
+    FunnelComponent.displayName = 'Funnel';
+    return FunnelComponent;
+  }, [currentStep]);
 
-  const Step = useMemo(
-    () => (props: StepProps) => {
+  const Step = useMemo(() => {
+    const StepComponent = (props: StepProps) => {
       return <>{props.children}</>;
-    },
-    [],
-  );
+    };
+
+    StepComponent.displayName = 'Step';
+    return StepComponent;
+  }, []);
 
   return { Funnel, Step, setStep, step: currentStep } as const;
 };

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import ParticipantForm from './components/Participant/ParticipantForm';
 import ResearcherForm from './components/Researcher/ResearcherForm';
 import useFunnel from './hooks/useFunnel';
+import { STEP } from './JoinPage.constants';
 import {
   contentContainer,
   joinLayout,
@@ -17,7 +18,6 @@ import {
 import Logo from '@/assets/images/logo.svg';
 import { ROLE } from '@/constants/config';
 import useSessionStorage from '@/hooks/useSessionStorage';
-import { STEP } from './JoinPage.constants';
 
 export default function JoinPage() {
   const role = useSessionStorage('role');

--- a/src/app/post/[post_id]/components/PostInfo/PostInfo.tsx
+++ b/src/app/post/[post_id]/components/PostInfo/PostInfo.tsx
@@ -8,9 +8,9 @@ import {
   postSubInfo,
   viewsContainer,
 } from './PostInfo.styles';
+import { UseQueryExperimentDetailsAPIResponse } from '../../hooks/useExperimentDetailsQuery';
 import DeleteConfirmModal from '../DeleteConfirmModal/DeleteConfirmModal';
 
-import { UseQueryExperimentDetailsAPIResponse } from '@/apis/hooks/useQueryExperimentDetailsAPI';
 import Icon from '@/components/Icon';
 import { colors } from '@/styles/colors';
 


### PR DESCRIPTION
## Issue Number

<!-- #이슈번호 -->
close #38 
## As-Is

<!-- 문제 상황 정의 -->
- build 시 에러 발생
- CI script X

## To-Be

<!-- 변경 사항 -->
- build 에러 해결
- github actions CI script 작성

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description

github actions CI 스크립트가 없어 빌드 오류를 그때그때 발견하기 어려웠습니다. github actions 스크립트를 작성하여 빌드가 성공하는지 PR을 올릴 때마다 돌도록 설정하였습니다. 

pnpm setup 을 사용하였고, lock 파일 그대로 설치하기 위해 --frozen-lockfile 명령어를 사용하였습니다.

```bash
- name: Install dependencies
   run: pnpm install --frozen-lockfile
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- 새 CI 워크플로우가 도입되어, pull request 발생 시 자동 빌드를 실행합니다.
  
- **Refactor**
	- 여러 컴포넌트에서 코드 일관성과 유지보수성이 개선되었습니다.
	- 아이콘 및 상수 관련 사용 방식이 재정비되어 UI 요소의 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->