### PR TITLE
[YS-270] Next Image 설정 변경

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,7 +12,6 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: 'dobby-dev-bucket.s3.ap-northeast-2.amazonaws.com',
-        pathname: '/resized-images/**',
       },
     ],
   },


### PR DESCRIPTION
## Issue Number
close #49 

<!-- #이슈번호 -->

## As-Is
next.config.mjs 이미지 path를 webP 경로로 제한 
 
<!-- 문제 상황 정의 -->

## To-Be
path 제거

<!-- 변경 사항 -->

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description
테스트를 위해 webP 경로가 아닌 기존 확장자 경로로 변경을 했는데
webP 경로로만 이미지 가져오도록 제한해둔 설정을 제거를 안했습니다 🫠🫠
급하게 이 설정만 제거하고 머지하겠습니다.
