### PR TITLE
[YS-388] 같은 계정으로 다른 역할 로그인 시 토스트 UI 처리

### DIFF
--- a/src/app/login/LoginError.tsx
+++ b/src/app/login/LoginError.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { PropsWithChildren, useEffect, useState } from 'react';
+
+import EmailToast from '../join/components/EmailToast/EmailToast';
+
+const LoginError = ({ children }: PropsWithChildren) => {
+  const queryClient = useQueryClient();
+
+  const [errorMessage, setErrorMessage] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const close = () => setIsOpen(false);
+
+  useEffect(() => {
+    const storedErrorMessage = queryClient.getQueryData<string>(['loginError']);
+
+    if (storedErrorMessage) {
+      setErrorMessage(storedErrorMessage);
+      setIsOpen(true);
+      queryClient.removeQueries({ queryKey: ['loginError'] });
+    }
+  }, [queryClient]);
+
+  return (
+    <>
+      {children}
+      {isOpen && (
+        <EmailToast title={errorMessage} isToastOpen={isOpen} setIsToastOpen={close} isError />
+      )}
+    </>
+  );
+};
+
+export default LoginError;

--- a/src/app/login/hooks/useGoogleLoginMutation.ts
+++ b/src/app/login/hooks/useGoogleLoginMutation.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
 import { API } from '@/apis/config';
@@ -6,6 +6,7 @@ import { googleLogin } from '@/apis/login';
 
 const useGoogleLoginMutation = () => {
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: ({ code, role }: { code: string; role: string }) => googleLogin(code, role),
@@ -21,7 +22,10 @@ const useGoogleLoginMutation = () => {
       sessionStorage.setItem('email', memberInfo.oauthEmail);
       router.push('/join');
     },
-    onError: () => {
+    onError: (error) => {
+      const errorMessage = error.message || '로그인 중 오류가 발생했습니다. 다시 시도해주세요.';
+      queryClient.setQueryData(['loginError'], errorMessage);
+
       router.push('/login');
     },
   });

--- a/src/app/login/hooks/useNaverLoginMutation.ts
+++ b/src/app/login/hooks/useNaverLoginMutation.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
 import { API } from '@/apis/config';
@@ -6,6 +6,7 @@ import { naverLogin, NaverLoginParams } from '@/apis/login';
 
 const useNaverLoginMutation = () => {
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: ({ code, role, state }: NaverLoginParams) => naverLogin({ code, role, state }),
@@ -19,10 +20,12 @@ const useNaverLoginMutation = () => {
       }
 
       sessionStorage.setItem('email', memberInfo.oauthEmail);
-
       router.push('/join');
     },
-    onError: () => {
+    onError: (error) => {
+      const errorMessage = error.message || '로그인 중 오류가 발생했습니다. 다시 시도해주세요.';
+      queryClient.setQueryData(['loginError'], errorMessage);
+
       router.push('/login');
     },
   });

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,40 +1,20 @@
-'use client';
-
-import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
 
 import LoginCard from './components/LoginCard/LoginCard';
+import LoginError from './LoginError';
 import {
   loginPageLayout,
   sloganContainer,
   sloganWrapper,
   loginCardContainer,
 } from './LoginPage.css';
-import EmailToast from '../join/components/EmailToast/EmailToast';
 
 import Logo from '@/assets/images/logo.svg';
 
 export default function LoginPage() {
-  const queryClient = useQueryClient();
-
-  const [errorMessage, setErrorMessage] = useState('');
-  const [isOpen, setIsOpen] = useState(false);
-  const close = () => setIsOpen(false);
-
-  useEffect(() => {
-    const storedErrorMessage = queryClient.getQueryData<string>(['loginError']);
-
-    if (storedErrorMessage) {
-      setErrorMessage(storedErrorMessage);
-      setIsOpen(true);
-      queryClient.removeQueries({ queryKey: ['loginError'] });
-    }
-  }, [queryClient]);
-
   return (
-    <>
+    <LoginError>
       <div className={loginPageLayout}>
         <div className={sloganContainer}>
           <Link href="/" aria-label="홈 화면으로 이동">
@@ -54,9 +34,6 @@ export default function LoginPage() {
           <LoginCard role="참여자" description={['정보를 등록하면', '딱 맞는 실험을 찾아드려요']} />
         </div>
       </div>
-      {isOpen && (
-        <EmailToast title={errorMessage} isToastOpen={isOpen} setIsToastOpen={close} isError />
-      )}
-    </>
+    </LoginError>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,9 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 
 import LoginCard from './components/LoginCard/LoginCard';
 import {
@@ -8,26 +12,51 @@ import {
   sloganWrapper,
   loginCardContainer,
 } from './LoginPage.css';
+import EmailToast from '../join/components/EmailToast/EmailToast';
 
 import Logo from '@/assets/images/logo.svg';
 
 export default function LoginPage() {
+  const queryClient = useQueryClient();
+
+  const [errorMessage, setErrorMessage] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const close = () => setIsOpen(false);
+
+  useEffect(() => {
+    const storedErrorMessage = queryClient.getQueryData<string>(['loginError']);
+
+    if (storedErrorMessage) {
+      setErrorMessage(storedErrorMessage);
+      setIsOpen(true);
+      queryClient.removeQueries({ queryKey: ['loginError'] });
+    }
+  }, [queryClient]);
+
   return (
-    <div className={loginPageLayout}>
-      <div className={sloganContainer}>
-        <Link href="/" aria-label="홈 화면으로 이동">
-          <Image src={Logo} alt="로고" />
-        </Link>
-        <div className={sloganWrapper}>
-          <span>작은 연결로 시작되는 큰 발견</span>
-          <br />
-          <span>그라밋이 도울게요</span>
+    <>
+      <div className={loginPageLayout}>
+        <div className={sloganContainer}>
+          <Link href="/" aria-label="홈 화면으로 이동">
+            <Image src={Logo} alt="로고" />
+          </Link>
+          <div className={sloganWrapper}>
+            <span>작은 연결로 시작되는 큰 발견</span>
+            <br />
+            <span>그라밋이 도울게요</span>
+          </div>
+        </div>
+        <div className={loginCardContainer}>
+          <LoginCard
+            role="연구자"
+            description={['그라밋에서 손쉽게', '연구 참여자를 모아보세요']}
+          />
+          <LoginCard role="참여자" description={['정보를 등록하면', '딱 맞는 실험을 찾아드려요']} />
         </div>
       </div>
-      <div className={loginCardContainer}>
-        <LoginCard role="연구자" description={['그라밋에서 손쉽게', '연구 참여자를 모아보세요']} />
-        <LoginCard role="참여자" description={['정보를 등록하면', '딱 맞는 실험을 찾아드려요']} />
-      </div>
-    </div>
+      {isOpen && (
+        <EmailToast title={errorMessage} isToastOpen={isOpen} setIsToastOpen={close} isError />
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Issue Number
close #84 

<!-- #이슈번호 -->

## As-Is

<!-- 문제 상황 정의 -->
- 같은 계정으로 다른 역할에 로그인할 경우 아무 처리 X

## To-Be
- [x] 같은 계정으로 다른 역할에 로그인할 경우, 로그인 페이지로 이동하면서 토스트 메세지로 알림
<!-- 변경 사항 -->

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/69b82aa1-7fc8-4409-9c1b-3fae54eafa67

## (Optional) Additional Description

### 로그인 에러 처리 (queryClient)

구글 로그인을 예로 들면, 구글 로그인 이후 GoogleLoginPage로 리다이렉트 되고, useEffect 내에서 googleLogin API를 호출합니다. 다른 역할로 이미 회원가입된 기록이 있따면 googleLogin API에서 에러가 발생하며, 이때 Toast UI를 띄워야 합니다.

하지만 현재 <u>API를 호출하는 페이지(GoogleLoginPage)와 Toast를 띄우는 페이지(LoginPage)가 다릅니다.</u> 따라서, 에러를 어떻게 저장해서 보여줄지 고민하다가 API 에러이기 때문에 서버 상태로 판단하였고, queryClient에서 관리하는 방법을 선택하였습니다.

해당 방식은 queryClient는 메모리에서 캐싱이 관리되기 때문에 새로고침 시에는 잘못된 캐싱 문제는 발생하지 않으며, navigate 시에도 잘못된 에러 메시지를 보여주지 않도록 removeQueries를 이용하여 바로 에러 객체를 제거하였습니다.

```ts
const useGoogleLoginMutation = () => {
  const router = useRouter();
  const queryClient = useQueryClient();

  return useMutation({
    ...
    onError: (error) => {
      const errorMessage = error.message || '로그인 중 오류가 발생했습니다. 다시 시도해주세요.';
      queryClient.setQueryData(['loginError'], errorMessage);

      router.push('/login');
    },
  });
};
```

### 로그인 에러를 처리하는 기능성 컴포넌트 (LoginError)

에러 처리 로직이 LoginPage에 추가되다보니, 에러 상황에만 발생하는 로직 때문에 LoginPage가 복잡해졌습니다. 따라서, 해당 부분을 분리하기로 결정하였습니다. 커스텀훅으로 분리하려고 하였지만 UI 로직도 섞여 있어 이를 함께 역할에 따라 분리하기 위해 기능성 컴포넌트로 만들고, 기존 LoginPage를 감싸 로직은 분리하고, children은 그대로 반환하는 방식을 선택하게 되었습니다.

```ts
const LoginError = ({ children }: PropsWithChildren) => {
  const queryClient = useQueryClient();

  const [errorMessage, setErrorMessage] = useState('');
  const [isOpen, setIsOpen] = useState(false);
  const close = () => setIsOpen(false);

  useEffect(() => {
    const storedErrorMessage = queryClient.getQueryData<string>(['loginError']);

    if (storedErrorMessage) {
      setErrorMessage(storedErrorMessage);
      setIsOpen(true);
      queryClient.removeQueries({ queryKey: ['loginError'] });
    }
  }, [queryClient]);

  return (
    <>
      {children}
      {isOpen && (
        <EmailToast title={errorMessage} isToastOpen={isOpen} setIsToastOpen={close} isError />
      )}
    </>
  );
};

export default LoginError;
```

```tsx
export default function LoginPage() {
  return (
    <LoginError>
      ...
    </LoginError>
  );
}

```

