### PR TITLE
[YS-207] next-auth를 활용한 토큰 관리 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "jira-prepare-commit-msg": "^1.7.2",
     "mixpanel-browser": "^2.61.0",
     "next": "14.2.22",
+    "next-auth": "^4.24.11",
     "react": "^18",
     "react-day-picker": "^9.5.0",
     "react-dom": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       next:
         specifier: 14.2.22
         version: 14.2.22(@babel/core@7.26.7)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-auth:
+        specifier: ^4.24.11
+        version: 4.24.11(next@14.2.22(@babel/core@7.26.7)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -817,6 +820,9 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2544,6 +2550,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  jose@4.15.9:
+    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2628,6 +2637,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2732,6 +2745,20 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
+  next-auth@4.24.11:
+    resolution: {integrity: sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==}
+    peerDependencies:
+      '@auth/core': 0.34.2
+      next: ^12.2.5 || ^13 || ^14 || ^15
+      nodemailer: ^6.6.5
+      react: ^17.0.2 || ^18 || ^19
+      react-dom: ^17.0.2 || ^18 || ^19
+    peerDependenciesMeta:
+      '@auth/core':
+        optional: true
+      nodemailer:
+        optional: true
+
   next@14.2.22:
     resolution: {integrity: sha512-Ps2caobQ9hlEhscLPiPm3J3SYhfwfpMqzsoCMZGWxt9jBRK9hoBZj2A37i8joKhsyth2EuVKDVJCTF5/H4iEDw==}
     engines: {node: '>=18.17.0'}
@@ -2753,9 +2780,16 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
+  oauth@0.9.15:
+    resolution: {integrity: sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@2.2.0:
+    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
+    engines: {node: '>= 6'}
 
   object-inspect@1.13.3:
     resolution: {integrity: sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==}
@@ -2785,12 +2819,19 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  oidc-token-hash@5.1.0:
+    resolution: {integrity: sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==}
+    engines: {node: ^10.13.0 || >=12.0.0}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  openid-client@5.7.1:
+    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2876,9 +2917,20 @@ packages:
     resolution: {integrity: sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  preact-render-to-string@5.2.6:
+    resolution: {integrity: sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.26.4:
+    resolution: {integrity: sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  pretty-format@3.8.0:
+    resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -3384,6 +3436,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -3488,6 +3544,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
@@ -4080,6 +4139,8 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@panva/hkdf@1.2.1': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -5491,8 +5552,8 @@ snapshots:
       '@typescript-eslint/parser': 8.18.2(eslint@8.57.1)(typescript@5.7.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.3(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -5511,7 +5572,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -5523,22 +5584,22 @@ snapshots:
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.18.2(eslint@8.57.1)(typescript@5.7.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -5549,7 +5610,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -6110,6 +6171,8 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  jose@4.15.9: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
@@ -6183,6 +6246,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
 
   math-intrinsics@1.1.0: {}
 
@@ -6279,6 +6346,21 @@ snapshots:
 
   neo-async@2.6.2: {}
 
+  next-auth@4.24.11(next@14.2.22(@babel/core@7.26.7)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@panva/hkdf': 1.2.1
+      cookie: 0.7.2
+      jose: 4.15.9
+      next: 14.2.22(@babel/core@7.26.7)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      oauth: 0.9.15
+      openid-client: 5.7.1
+      preact: 10.26.4
+      preact-render-to-string: 5.2.6(preact@10.26.4)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      uuid: 8.3.2
+
   next@14.2.22(@babel/core@7.26.7)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.22
@@ -6306,7 +6388,11 @@ snapshots:
 
   node-releases@2.0.19: {}
 
+  oauth@0.9.15: {}
+
   object-assign@4.1.1: {}
+
+  object-hash@2.2.0: {}
 
   object-inspect@1.13.3: {}
 
@@ -6347,6 +6433,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
 
+  oidc-token-hash@5.1.0: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -6354,6 +6442,13 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  openid-client@5.7.1:
+    dependencies:
+      jose: 4.15.9
+      lru-cache: 6.0.0
+      object-hash: 2.2.0
+      oidc-token-hash: 5.1.0
 
   optionator@0.9.4:
     dependencies:
@@ -6434,7 +6529,16 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  preact-render-to-string@5.2.6(preact@10.26.4):
+    dependencies:
+      preact: 10.26.4
+      pretty-format: 3.8.0
+
+  preact@10.26.4: {}
+
   prelude-ls@1.2.1: {}
+
+  pretty-format@3.8.0: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -7038,6 +7142,8 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  uuid@8.3.2: {}
+
   vary@1.1.2: {}
 
   vite-node@1.6.0(@types/node@20.17.10)(terser@5.37.0):
@@ -7174,6 +7280,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yaml@1.10.2:
     optional: true

--- a/src/apis/config.ts
+++ b/src/apis/config.ts
@@ -68,11 +68,11 @@ API.interceptors.response.use(
           const userInfo = await updateAccessToken(refreshToken);
 
           // Next-Auth 재로그인
-          await loginWithCredentials(
-            userInfo.accessToken,
-            userInfo.refreshToken,
-            userInfo.memberInfo.role,
-          );
+          await loginWithCredentials({
+            accessToken: userInfo.accessToken,
+            refreshToken: userInfo.refreshToken,
+            role: userInfo.memberInfo.role,
+          });
 
           originalRequest.headers.Authorization = `Bearer ${userInfo.accessToken}`;
           API.defaults.headers.Authorization = `Bearer ${userInfo.accessToken}`;

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -11,6 +11,9 @@ export const authOptions: NextAuthOptions = {
         accessToken: { label: 'accessToken', type: 'text' },
         refreshToken: { label: 'refreshToken', type: 'text' },
         role: { label: 'role', type: 'text' },
+        isTempUser: { label: 'isTempUser', type: 'text' },
+        oauthEmail: { label: 'oauthEmail', type: 'text' },
+        provider: { label: 'provider', type: 'text' },
       },
       async authorize(credentials) {
         if (!credentials?.accessToken || !credentials?.refreshToken || !credentials?.role) {
@@ -23,6 +26,9 @@ export const authOptions: NextAuthOptions = {
           accessToken: credentials.accessToken,
           refreshToken: credentials.refreshToken,
           role: credentials.role,
+          isTempUser: credentials.isTempUser === 'true',
+          oauthEmail: credentials.oauthEmail,
+          provider: credentials.provider,
         };
       },
     }),
@@ -34,6 +40,15 @@ export const authOptions: NextAuthOptions = {
         token.accessToken = user.accessToken;
         token.refreshToken = user.refreshToken;
         token.role = user.role;
+
+        if (user.isTempUser && user.oauthEmail && user.provider) {
+          token.isTempUser = user.isTempUser;
+          token.oauthEmail = user.oauthEmail;
+          token.provider = user.provider;
+
+          const currentTime = Math.floor(Date.now() / 1000);
+          token.exp = currentTime + 15 * 60; // 15분 후 만료
+        }
       }
 
       // useSession의 update 트리거 시 토큰 정보 갱신
@@ -51,6 +66,13 @@ export const authOptions: NextAuthOptions = {
       session.accessToken = token.accessToken;
       session.refreshToken = token.refreshToken;
       session.role = token.role;
+
+      // 임시 사용자 플래그 추가
+      if (token.isTempUser && token.oauthEmail && token.provider) {
+        session.isTempUser = token.isTempUser;
+        session.oauthEmail = token.oauthEmail;
+        session.provider = token.provider;
+      }
 
       return session;
     },

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,66 @@
+import NextAuth from 'next-auth';
+import { NextAuthOptions } from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+
+export const authOptions: NextAuthOptions = {
+  secret: process.env.NEXTAUTH_SECRET,
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        accessToken: { label: 'accessToken', type: 'text' },
+        refreshToken: { label: 'refreshToken', type: 'text' },
+        role: { label: 'role', type: 'text' },
+      },
+      async authorize(credentials) {
+        if (!credentials?.accessToken || !credentials?.refreshToken || !credentials?.role) {
+          return null;
+        }
+
+        // 이미 인증 정보가 있는 경우 그대로 반환
+        return {
+          id: 'id', // 필수 반환값
+          accessToken: credentials.accessToken,
+          refreshToken: credentials.refreshToken,
+          role: credentials.role,
+        };
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, user, trigger, session }) {
+      // 초기 로그인 시 토큰에 사용자 정보 추가
+      if (user) {
+        token.accessToken = user.accessToken;
+        token.refreshToken = user.refreshToken;
+        token.role = user.role;
+      }
+
+      // useSession의 update 트리거 시 토큰 정보 갱신
+      if (trigger === 'update' && session) {
+        if (session.accessToken) token.accessToken = session.accessToken;
+        if (session.refreshToken) token.refreshToken = session.refreshToken;
+        if (session.role) token.role = session.role;
+        return token;
+      }
+
+      return token;
+    },
+    async session({ session, token }) {
+      // 세션에 토큰 정보 추가
+      session.accessToken = token.accessToken;
+      session.refreshToken = token.refreshToken;
+      session.role = token.role;
+
+      return session;
+    },
+  },
+  session: {
+    strategy: 'jwt',
+    maxAge: 1 * 60 * 60, // 1시간
+  },
+};
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/src/app/home/components/ExperimentPostContainer/ExperimentPostCardListContainer/ExperimentPostCardListContainer.tsx
+++ b/src/app/home/components/ExperimentPostContainer/ExperimentPostCardListContainer/ExperimentPostCardListContainer.tsx
@@ -15,10 +15,13 @@ import Spinner from '@/components/Spinner/Spinner';
 
 interface PostCardListContainerProps {
   filters: ExperimentPostListFilters;
-  isLoading: boolean;
+  isUserInfoLoading: boolean;
 }
 
-const ExperimentPostCardListContainer = ({ filters, isLoading }: PostCardListContainerProps) => {
+const ExperimentPostCardListContainer = ({
+  filters,
+  isUserInfoLoading,
+}: PostCardListContainerProps) => {
   const {
     data: postListData,
     hasNextPage,
@@ -26,9 +29,9 @@ const ExperimentPostCardListContainer = ({ filters, isLoading }: PostCardListCon
     isFetchingNextPage,
     isFetching,
     isLoading: isListLoading,
-  } = useExperimentPostListQuery(filters, isLoading);
+  } = useExperimentPostListQuery(filters, isUserInfoLoading);
 
-  if (isListLoading) {
+  if (isUserInfoLoading || isListLoading) {
     return (
       <div className={emptyViewLayout}>
         <Spinner />

--- a/src/app/home/components/ExperimentPostContainer/ExperimentPostContainer.tsx
+++ b/src/app/home/components/ExperimentPostContainer/ExperimentPostContainer.tsx
@@ -48,7 +48,7 @@ const ExperimentPostContainer = () => {
       </div>
 
       {/* 공고 목록 */}
-      <ExperimentPostCardListContainer filters={filters} isLoading={isUserInfoLoading} />
+      <ExperimentPostCardListContainer filters={filters} isUserInfoLoading={isUserInfoLoading} />
     </div>
   );
 };

--- a/src/app/home/components/ExperimentPostContainer/ExperimentPostContainer.tsx
+++ b/src/app/home/components/ExperimentPostContainer/ExperimentPostContainer.tsx
@@ -15,7 +15,7 @@ import JoinCheckbox from '@/app/join/components/JoinCheckboxContainer/JoinCheckb
 import Icon from '@/components/Icon';
 
 const ExperimentPostContainer = () => {
-  const { userInfo, isLoading: isUserInfoLoading } = useUserInfo();
+  const { userInfo, isLoading: isUserInfoLoading, isSessionReady } = useUserInfo();
 
   const {
     filters,
@@ -23,7 +23,7 @@ const ExperimentPostContainer = () => {
     handleFilterChange,
     handleToggleRecruitStatus,
     handleResetFilter,
-  } = useExperimentFilters(userInfo);
+  } = useExperimentFilters(isSessionReady, userInfo);
 
   return (
     <div className={postContainerLayout}>

--- a/src/app/home/hooks/useExperimentFilters.ts
+++ b/src/app/home/hooks/useExperimentFilters.ts
@@ -5,7 +5,10 @@ import { calculateAgeFromBirthDate, filterParticipantInfo } from '../home.utils'
 import { ParticipantResponse, ResearcherResponse } from '@/apis/login';
 import { ExperimentPostListFilters } from '@/apis/post';
 
-export const useExperimentFilters = (userInfo?: ParticipantResponse | ResearcherResponse) => {
+export const useExperimentFilters = (
+  isSessionReady: boolean,
+  userInfo?: ParticipantResponse | ResearcherResponse,
+) => {
   const participantInfo = filterParticipantInfo(userInfo);
   const [filters, setFilters] = useState<ExperimentPostListFilters>(
     {} as ExperimentPostListFilters,
@@ -31,8 +34,10 @@ export const useExperimentFilters = (userInfo?: ParticipantResponse | Researcher
     });
   };
 
-  // 참여자 성별/나이 자동 필터링
   useEffect(() => {
+    if (!isSessionReady) return;
+
+    // 참여자일 경우 자동 필터링 적용
     if (participantInfo) {
       setFilters((prev) => ({
         ...prev,
@@ -40,13 +45,15 @@ export const useExperimentFilters = (userInfo?: ParticipantResponse | Researcher
         gender: participantInfo.gender,
         age: calculateAgeFromBirthDate(participantInfo.birthDate),
       }));
-    } else {
-      setFilters((prev) => ({
-        ...prev,
-        recruitStatus: 'ALL',
-      }));
+
+      return;
     }
-  }, [participantInfo]);
+
+    setFilters((prev) => ({
+      ...prev,
+      recruitStatus: 'ALL',
+    }));
+  }, [isSessionReady, participantInfo]);
 
   return {
     filters,

--- a/src/app/home/hooks/useUserInfo.ts
+++ b/src/app/home/hooks/useUserInfo.ts
@@ -1,22 +1,32 @@
 'use client';
+
+import { useSession } from 'next-auth/react';
+
 import useParticipantInfoQuery from './useParticipantInfoQuery';
 import useResearcherInfoQuery from './useResearcherInfoQuery';
 
 import { ROLE } from '@/constants/config';
-import useSessionStorage from '@/hooks/useSessionStorage';
 
 const useUserInfo = () => {
-  const { value: role } = useSessionStorage('role');
-  const isParticipant = role === ROLE.participant;
-  const isResearcher = role === ROLE.researcher;
+  const { data: session, status } = useSession();
+
+  const role = session?.role;
+  const isSessionReady = status !== 'loading';
+  const isParticipant = isSessionReady && role === ROLE.participant;
+  const isResearcher = isSessionReady && role === ROLE.researcher;
 
   const participantQuery = useParticipantInfoQuery({ enabled: isParticipant });
   const researcherQuery = useResearcherInfoQuery({ enabled: isResearcher });
 
+  const isLoading = !isSessionReady || participantQuery.isLoading || researcherQuery.isLoading;
+
   return {
     userInfo: isParticipant ? participantQuery.data : researcherQuery.data,
-    isLoading: participantQuery.isLoading || researcherQuery.isLoading,
+    isLoading,
     isError: participantQuery.isError || researcherQuery.isError,
+    isSessionReady,
+    isResearcher,
+    isParticipant,
   };
 };
 

--- a/src/app/join/components/Participant/ParticipantForm.tsx
+++ b/src/app/join/components/Participant/ParticipantForm.tsx
@@ -9,14 +9,15 @@ import JoinSuccessStep from '../JoinSuccessStep/JoinSuccessStep';
 
 import { Participant } from '.';
 
-import useSessionStorage from '@/hooks/useSessionStorage';
 import ParticipantJoinSchema, {
   ParticipantJoinSchemaType,
 } from '@/schema/join/ParticipantJoinSchema';
+import { useSession } from 'next-auth/react';
 
 const ParticipantForm = () => {
-  const { value: oauthEmail } = useSessionStorage('email');
-  const { value: provider } = useSessionStorage('provider');
+  const { data: session } = useSession();
+  const oauthEmail = session?.oauthEmail;
+  const provider = session?.provider;
 
   const { mutate: joinParticipant } = useParticipantJoinMutation();
 
@@ -64,7 +65,7 @@ const ParticipantForm = () => {
       participantMethods.setValue('oauthEmail', oauthEmail);
       participantMethods.setValue('provider', provider as 'GOOGLE' | 'NAVER');
     }
-  }, [oauthEmail, participantMethods, provider]);
+  }, [participantMethods, oauthEmail, provider]);
 
   return (
     <FormProvider {...participantMethods}>

--- a/src/app/join/components/Researcher/ResearcherForm.tsx
+++ b/src/app/join/components/Researcher/ResearcherForm.tsx
@@ -9,14 +9,15 @@ import JoinSuccessStep from '../JoinSuccessStep/JoinSuccessStep';
 
 import { Researcher } from '.';
 
-import useSessionStorage from '@/hooks/useSessionStorage';
 import ResearcherJoinSchema, { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
+import { useSession } from 'next-auth/react';
 
 const ResearcherForm = () => {
-  const { value: oauthEmail } = useSessionStorage('email');
-  const { value: provider } = useSessionStorage('provider');
-
   const { mutate: joinResearcher } = useResearcherJoinMutation();
+
+  const { data: session } = useSession();
+  const oauthEmail = session?.oauthEmail;
+  const provider = session?.provider;
 
   const { Funnel, Step, setStep } = useFunnel(['email', 'info', 'success'] as const);
 
@@ -45,7 +46,7 @@ const ResearcherForm = () => {
       researcherMethods.setValue('oauthEmail', oauthEmail);
       researcherMethods.setValue('provider', provider as 'GOOGLE' | 'NAVER');
     }
-  }, [oauthEmail, researcherMethods, provider]);
+  }, [researcherMethods, oauthEmail, provider]);
 
   return (
     <FormProvider {...researcherMethods}>

--- a/src/app/join/hooks/useParticipantJoinMutation.ts
+++ b/src/app/join/hooks/useParticipantJoinMutation.ts
@@ -2,14 +2,14 @@ import { useMutation } from '@tanstack/react-query';
 
 import { API } from '@/apis/config';
 import { joinParticipant } from '@/apis/login';
+import { loginWithCredentials } from '@/lib/auth-utils';
 
 const useParticipantJoinMutation = () => {
   return useMutation({
     mutationFn: joinParticipant,
-    onSuccess: ({ accessToken, refreshToken, memberInfo }) => {
+    onSuccess: async ({ accessToken, refreshToken, memberInfo }) => {
       API.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
-      sessionStorage.setItem('refreshToken', refreshToken);
-      sessionStorage.setItem('role', memberInfo.role);
+      await loginWithCredentials({ accessToken, refreshToken, role: memberInfo.role });
     },
   });
 };

--- a/src/app/join/hooks/useResearcherJoinMutation.ts
+++ b/src/app/join/hooks/useResearcherJoinMutation.ts
@@ -2,14 +2,14 @@ import { useMutation } from '@tanstack/react-query';
 
 import { API } from '@/apis/config';
 import { joinResearcher } from '@/apis/login';
+import { loginWithCredentials } from '@/lib/auth-utils';
 
 const useResearcherJoinMutation = () => {
   return useMutation({
     mutationFn: joinResearcher,
-    onSuccess: ({ accessToken, refreshToken, memberInfo }) => {
+    onSuccess: async ({ accessToken, refreshToken, memberInfo }) => {
       API.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
-      sessionStorage.setItem('refreshToken', refreshToken);
-      sessionStorage.setItem('role', memberInfo.role);
+      await loginWithCredentials({ accessToken, refreshToken, role: memberInfo.role });
     },
   });
 };

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -19,10 +19,12 @@ import {
 
 import Logo from '@/assets/images/logo.svg';
 import { ROLE } from '@/constants/config';
-import useSessionStorage from '@/hooks/useSessionStorage';
+import { useSession } from 'next-auth/react';
 
 export default function JoinPage() {
-  const { value: role } = useSessionStorage('role');
+  const { data: session } = useSession();
+  const role = session?.role;
+
   const { step } = useFunnel(['email', 'info', 'success'] as const);
 
   // TODO: 추후 스켈레톤 처리

--- a/src/app/login/google/page.tsx
+++ b/src/app/login/google/page.tsx
@@ -1,26 +1,41 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import React, { useEffect, useRef } from 'react';
 
 import { emptyLayout } from './GoogleLoginPage.css';
 import useGoogleLoginMutation from '../hooks/useGoogleLoginMutation';
 
 export default function GoogleLoginPage() {
-  const { mutate: googleLogin } = useGoogleLoginMutation();
+  const router = useRouter();
   const searchParams = useSearchParams();
   const code = searchParams.get('code');
   const state = searchParams.get('state');
-
   const isSubmitted = useRef(false);
+
+  const { mutate: googleLogin } = useGoogleLoginMutation({
+    onSuccessLogin: () => {
+      router.push('/');
+    },
+    onSuccessJoin: (oauthEmail: string) => {
+      if (state) {
+        const [role, provider] = state.split('|');
+        sessionStorage.setItem('email', oauthEmail);
+        sessionStorage.setItem('role', role);
+        sessionStorage.setItem('provider', provider);
+        router.push('/join');
+      }
+    },
+    onError: () => {
+      router.push('/login');
+    },
+  });
 
   useEffect(() => {
     if (isSubmitted.current) return;
 
     if (code && state) {
-      const [role, provider] = state.split('|');
-      sessionStorage.setItem('role', role);
-      sessionStorage.setItem('provider', provider);
+      const [role, _] = state.split('|');
       googleLogin({ code: encodeURIComponent(code), role });
       isSubmitted.current = true;
     }

--- a/src/app/login/google/page.tsx
+++ b/src/app/login/google/page.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useRef } from 'react';
 
 import { emptyLayout } from './GoogleLoginPage.css';
 import useGoogleLoginMutation from '../hooks/useGoogleLoginMutation';
+import { joinWithCredentials } from '@/lib/auth-utils';
 
 export default function GoogleLoginPage() {
   const router = useRouter();
@@ -17,12 +18,16 @@ export default function GoogleLoginPage() {
     onSuccessLogin: () => {
       router.push('/');
     },
-    onSuccessJoin: (oauthEmail: string) => {
+    onSuccessJoin: async (oauthEmail: string) => {
       if (state) {
         const [role, provider] = state.split('|');
-        sessionStorage.setItem('email', oauthEmail);
-        sessionStorage.setItem('role', role);
-        sessionStorage.setItem('provider', provider);
+
+        await joinWithCredentials({
+          oauthEmail,
+          role,
+          provider,
+        });
+
         router.push('/join');
       }
     },

--- a/src/app/login/hooks/useGoogleLoginMutation.ts
+++ b/src/app/login/hooks/useGoogleLoginMutation.ts
@@ -23,7 +23,7 @@ const useGoogleLoginMutation = ({
     onSuccess: async ({ isRegistered, accessToken, refreshToken, memberInfo }) => {
       if (isRegistered) {
         API.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
-        await loginWithCredentials(accessToken, refreshToken, memberInfo.role);
+        await loginWithCredentials({ accessToken, refreshToken, role: memberInfo.role });
 
         identifyUser(memberInfo.oauthEmail);
         setUserProperties({ email: memberInfo.oauthEmail, role: memberInfo.role });

--- a/src/app/login/hooks/useNaverLoginMutation.ts
+++ b/src/app/login/hooks/useNaverLoginMutation.ts
@@ -1,37 +1,44 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
 
-import { API } from '@/apis/config';
 import { naverLogin, NaverLoginParams } from '@/apis/login';
+import { loginWithCredentials } from '@/lib/auth-utils';
 import { identifyUser, setUserProperties } from '@/lib/mixpanelClient';
+import { API } from '@/apis/config';
 
-const useNaverLoginMutation = () => {
-  const router = useRouter();
+interface UseNaverLoginMutationProps {
+  onSuccessLogin: () => void;
+  onSuccessJoin: (oauthEmail: string) => void;
+  onError: () => void;
+}
+
+const useNaverLoginMutation = ({
+  onSuccessLogin,
+  onSuccessJoin,
+  onError,
+}: UseNaverLoginMutationProps) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: ({ code, role, state }: NaverLoginParams) => naverLogin({ code, role, state }),
-    onSuccess: ({ isRegistered, accessToken, refreshToken, memberInfo }) => {
+    onSuccess: async ({ isRegistered, accessToken, refreshToken, memberInfo }) => {
       if (isRegistered) {
         API.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
-        sessionStorage.setItem('refreshToken', refreshToken);
-        sessionStorage.setItem('role', memberInfo.role);
+        await loginWithCredentials(accessToken, refreshToken, memberInfo.role);
 
         identifyUser(memberInfo.oauthEmail);
         setUserProperties({ email: memberInfo.oauthEmail, role: memberInfo.role });
 
-        router.push('/');
+        onSuccessLogin();
         return;
       }
 
-      sessionStorage.setItem('email', memberInfo.oauthEmail);
-      router.push('/join');
+      onSuccessJoin(memberInfo.oauthEmail);
     },
     onError: (error) => {
       const errorMessage = error.message || '로그인 중 오류가 발생했습니다. 다시 시도해주세요.';
       queryClient.setQueryData(['loginError'], errorMessage);
 
-      router.push('/login');
+      onError();
     },
   });
 };

--- a/src/app/login/hooks/useNaverLoginMutation.ts
+++ b/src/app/login/hooks/useNaverLoginMutation.ts
@@ -23,7 +23,7 @@ const useNaverLoginMutation = ({
     onSuccess: async ({ isRegistered, accessToken, refreshToken, memberInfo }) => {
       if (isRegistered) {
         API.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
-        await loginWithCredentials(accessToken, refreshToken, memberInfo.role);
+        await loginWithCredentials({ accessToken, refreshToken, role: memberInfo.role });
 
         identifyUser(memberInfo.oauthEmail);
         setUserProperties({ email: memberInfo.oauthEmail, role: memberInfo.role });

--- a/src/app/login/naver/page.tsx
+++ b/src/app/login/naver/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef } from 'react';
 
 import { emptyLayout } from './NaverLoginPage.css';
 import useNaverLoginMutation from '../hooks/useNaverLoginMutation';
+import { joinWithCredentials } from '@/lib/auth-utils';
 
 export default function NaverLoginPage() {
   const router = useRouter();
@@ -17,12 +18,16 @@ export default function NaverLoginPage() {
     onSuccessLogin: () => {
       router.push('/');
     },
-    onSuccessJoin: (oauthEmail: string) => {
+    onSuccessJoin: async (oauthEmail: string) => {
       if (stateParams) {
         const [_, role, provider] = stateParams.split('|');
-        sessionStorage.setItem('email', oauthEmail);
-        sessionStorage.setItem('role', role);
-        sessionStorage.setItem('provider', provider);
+
+        await joinWithCredentials({
+          oauthEmail,
+          role,
+          provider,
+        });
+
         router.push('/join');
       }
     },

--- a/src/app/login/naver/page.tsx
+++ b/src/app/login/naver/page.tsx
@@ -1,25 +1,41 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 
 import { emptyLayout } from './NaverLoginPage.css';
 import useNaverLoginMutation from '../hooks/useNaverLoginMutation';
 
 export default function NaverLoginPage() {
-  const { mutate: naverLogin } = useNaverLoginMutation();
+  const router = useRouter();
   const searchParams = useSearchParams();
   const code = searchParams.get('code');
   const stateParams = searchParams.get('state');
   const isSubmitted = useRef(false);
 
+  const { mutate: naverLogin } = useNaverLoginMutation({
+    onSuccessLogin: () => {
+      router.push('/');
+    },
+    onSuccessJoin: (oauthEmail: string) => {
+      if (stateParams) {
+        const [_, role, provider] = stateParams.split('|');
+        sessionStorage.setItem('email', oauthEmail);
+        sessionStorage.setItem('role', role);
+        sessionStorage.setItem('provider', provider);
+        router.push('/join');
+      }
+    },
+    onError: () => {
+      router.push('/login');
+    },
+  });
+
   useEffect(() => {
     if (isSubmitted.current) return;
 
     if (code && stateParams) {
-      const [state, role, provider] = stateParams.split('|');
-      sessionStorage.setItem('role', role);
-      sessionStorage.setItem('provider', provider);
+      const [state, role, _] = stateParams.split('|');
       naverLogin({ code: encodeURIComponent(code), role, state: encodeURIComponent(state) });
       isSubmitted.current = true;
     }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -3,6 +3,7 @@
 import { isServer, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { usePathname } from 'next/navigation';
+import { SessionProvider } from 'next-auth/react';
 import { useEffect } from 'react';
 
 import { setUserProperties, trackEvent } from '@/lib/mixpanelClient';
@@ -37,11 +38,13 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   }, [pathname]);
 
   return (
-    <MSWProvider>
-      <QueryClientProvider client={queryClient}>
-        {children}
-        <ReactQueryDevtools initialIsOpen={false} />
-      </QueryClientProvider>
-    </MSWProvider>
+    <SessionProvider>
+      <MSWProvider>
+        <QueryClientProvider client={queryClient}>
+          {children}
+          <ReactQueryDevtools initialIsOpen={false} />
+        </QueryClientProvider>
+      </MSWProvider>
+    </SessionProvider>
   );
 }

--- a/src/app/user/leave/page.tsx
+++ b/src/app/user/leave/page.tsx
@@ -29,6 +29,7 @@ import JoinInput from '@/app/join/components/JoinInput/JoinInput';
 import Icon from '@/components/Icon';
 import LeaveSchema, { LeaveSchemaType } from '@/schema/profile/LeaveSchema';
 import { colors } from '@/styles/colors';
+import { signOut } from 'next-auth/react';
 
 const useLeaveMutation = () => {
   return useMutation({
@@ -68,7 +69,7 @@ const LeavePage = () => {
 
     leave(formattedData, {
       onSuccess: () => {
-        router.push('/user/success');
+        signOut({ callbackUrl: '/user/success' });
       },
     });
   };

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,16 +3,12 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { buttonContainer, contactButton, headerLayout, image, loginButton } from './Header.css';
-import Menu from './Menu';
+import { headerLayout, image } from './Header.css';
 import Logo from '../../assets/images/logo.svg';
 
-import useUserInfo from '@/app/home/hooks/useUserInfo';
-import { isResearcherInfo } from '@/utils/typeGuard';
+import RightHeader from './RightHeader/RightHeader';
 
 const Header = () => {
-  const { userInfo } = useUserInfo();
-
   return (
     <div className={headerLayout}>
       <Link href="/">
@@ -26,22 +22,7 @@ const Header = () => {
           style={{ width: 'auto', height: 'auto' }}
         />
       </Link>
-      <div className={buttonContainer}>
-        {userInfo ? (
-          <>
-            {isResearcherInfo(userInfo) && (
-              <Link href="/upload">
-                <button className={contactButton}>실험 공고 등록</button>
-              </Link>
-            )}
-            <Menu userInfo={userInfo} />
-          </>
-        ) : (
-          <Link href="/login" className={loginButton}>
-            로그인
-          </Link>
-        )}
-      </div>
+      <RightHeader />
     </div>
   );
 };

--- a/src/components/Header/Menu.tsx
+++ b/src/components/Header/Menu.tsx
@@ -9,6 +9,7 @@ import Icon from '@/components/Icon';
 import useSessionStorage from '@/hooks/useSessionStorage';
 import { logoutUser } from '@/lib/mixpanelClient';
 import { isResearcherInfo } from '@/utils/typeGuard';
+import { logout } from '@/lib/auth-utils';
 
 interface MenuProps {
   userInfo: ParticipantResponse | ResearcherResponse;
@@ -18,10 +19,10 @@ const Menu = ({ userInfo }: MenuProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const { clear } = useSessionStorage();
 
-  const logout = () => {
+  const handleLogout = async () => {
     clear();
     logoutUser();
-    window.location.href = '/';
+    await logout();
   };
 
   return (
@@ -54,7 +55,7 @@ const Menu = ({ userInfo }: MenuProps) => {
                 내가 쓴 글
               </Link>
             )}
-            <Select.Label className={selectItem} onClick={logout}>
+            <Select.Label className={selectItem} onClick={handleLogout}>
               로그아웃
             </Select.Label>
           </Select.Group>

--- a/src/components/Header/RightHeader/RightHeader.tsx
+++ b/src/components/Header/RightHeader/RightHeader.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+
+import { buttonContainer, contactButton, loginButton } from '../Header.css';
+import Menu from '../Menu';
+
+import useUserInfo from '@/app/home/hooks/useUserInfo';
+
+const RightHeader = () => {
+  const { userInfo, isLoading, isResearcher } = useUserInfo();
+
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <div className={buttonContainer}>
+      {userInfo ? (
+        <>
+          {isResearcher && (
+            <Link href="/upload" className={contactButton}>
+              실험 공고 등록
+            </Link>
+          )}
+          <Menu userInfo={userInfo} />
+        </>
+      ) : (
+        <Link href="/login" className={loginButton}>
+          로그인
+        </Link>
+      )}
+    </div>
+  );
+};
+
+export default RightHeader;

--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -1,0 +1,21 @@
+import { signIn, signOut } from 'next-auth/react';
+
+// 로그인 처리 함수
+export const loginWithCredentials = async (
+  accessToken: string,
+  refreshToken: string,
+  role: string,
+) => {
+  // Next-Auth 세션에 토큰 저장
+  await signIn('credentials', {
+    accessToken,
+    refreshToken,
+    role,
+    redirect: false,
+  });
+};
+
+// 로그아웃 처리 함수
+export const logout = async () => {
+  await signOut({ callbackUrl: '/' });
+};

--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -1,17 +1,45 @@
 import { signIn, signOut } from 'next-auth/react';
 
+interface LoginWithCredentialsParams {
+  accessToken: string;
+  refreshToken: string;
+  role: string;
+}
+
+interface JoinWithCredentialsParams {
+  oauthEmail: string;
+  role: string;
+  provider: string;
+}
+
 // 로그인 처리 함수
-export const loginWithCredentials = async (
-  accessToken: string,
-  refreshToken: string,
-  role: string,
-) => {
-  // Next-Auth 세션에 토큰 저장
+export const loginWithCredentials = async ({
+  accessToken,
+  refreshToken,
+  role,
+}: LoginWithCredentialsParams) => {
   await signIn('credentials', {
     accessToken,
     refreshToken,
     role,
     redirect: false,
+  });
+};
+
+// 회원가입 임시 로그인 처리 함수
+export const joinWithCredentials = async ({
+  oauthEmail,
+  role,
+  provider,
+}: JoinWithCredentialsParams) => {
+  await signIn('credentials', {
+    accessToken: 'temp-token',
+    refreshToken: 'temp-token',
+    role,
+    isTempUser: 'true',
+    redirect: false,
+    oauthEmail,
+    provider,
   });
 };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+
+const goToLogin = (request: NextRequest) => {
+  return NextResponse.redirect(new URL('/login', request.url));
+};
+
+const goToHome = (request: NextRequest) => {
+  return NextResponse.redirect(new URL('/', request.url));
+};
+
+export async function middleware(request: NextRequest) {
+  const session = await getToken({
+    req: request,
+    secret: process.env.NEXTAUTH_SECRET,
+  });
+
+  const isJoinPage = request.nextUrl.pathname.startsWith('/join');
+  const isUserPage = request.nextUrl.pathname.startsWith('/user');
+  const isMyPostsPage = request.nextUrl.pathname.startsWith('/my-posts');
+
+  if (isJoinPage) {
+    // 비로그인 사용자는 로그인 페이지로 이동
+    // TODO: 회원가입 유저와 직접 접근하는 유저 구분 필요.
+    // if (!session) {
+    //   return goToLogin(request);
+    // }
+
+    // 로그인 사용자는 홈으로 이동
+    if (session) {
+      return goToHome(request);
+    }
+  }
+
+  if (isUserPage || isMyPostsPage) {
+    if (!session) {
+      return goToLogin(request);
+    }
+  }
+
+  return NextResponse.next();
+}
+
+// 미들웨어가 실행될 경로 지정
+export const config = {
+  matcher: ['/join/:path*', '/my-posts/:path*', '/user/:path*'],
+};

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,26 @@
+import { DefaultSession } from 'next-auth';
+
+// Next-Auth 타입 확장
+declare module 'next-auth' {
+  interface Session extends DefaultSession {
+    accessToken?: string;
+    refreshToken?: string;
+    role?: string;
+    error?: string;
+  }
+
+  interface User {
+    accessToken: string;
+    refreshToken: string;
+    role: string;
+  }
+}
+
+// JWT 타입 확장
+declare module 'next-auth/jwt' {
+  interface JWT {
+    accessToken: string;
+    refreshToken: string;
+    role: string;
+  }
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -6,13 +6,18 @@ declare module 'next-auth' {
     accessToken?: string;
     refreshToken?: string;
     role?: string;
-    error?: string;
+    isTempUser?: boolean;
+    oauthEmail?: string;
+    provider?: string;
   }
 
   interface User {
     accessToken: string;
     refreshToken: string;
     role: string;
+    isTempUser?: boolean;
+    oauthEmail?: string;
+    provider?: string;
   }
 }
 
@@ -22,5 +27,11 @@ declare module 'next-auth/jwt' {
     accessToken: string;
     refreshToken: string;
     role: string;
+    iat: number;
+    exp: number;
+    jti: string;
+    isTempUser?: boolean;
+    oauthEmail?: string;
+    provider?: string;
   }
 }


### PR DESCRIPTION
## Issue Number

<!-- #이슈번호 -->
#27 

## As-Is

<!-- 문제 상황 정의 -->
- sessionStorage로 관리되면서 보안적으로 좋지 않으며, 유효성을 판단하기가 어려웠음.
  - sessionStorage가 사용자의 실수로 날라갈 경우, API 호출 자체가 어려운 상황
- 회원 정보 페이지, 회원가입 페이지에 접근이 자유로워 비로그인 상태로 해당 페이지 접근 시 오류 발생 

## To-Be

<!-- 변경 사항 -->
- sessionStorage로 관리하던 accessToken, refreshToken, role, oauthEmail, provider 모두 next-auth로 통합 관리
  - 토큰값이 외부로 노출되지 않아 보안상 안전
  - 토큰값 조작 불가
  - 토큰값을 관리하기 수월 -> 기존에는 인증/인가를 관리하기 위해 무조건 sessionStorage에 접근해야해서 클라이언트로만 처리가 가능했는데, SSR도 고려 가능
  - 회원가입 중인 유저를 관리하기 위해 joinWithCredentials 함수 분리
- middleware로 페이지 접근 제어
- 로그인 시 라우팅 로직을 밖으로 분리

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description

### next-auth
- 기존의 sessionStorage로 처리하던 부분을 next-auth로 통합 관리하도록 처리하였습니다.
  - 유저는 loginWIthCredentials, 회원가입을 위한 임시 유저는 joinWithCredentials 를 호출해서 처리하고 있습니다.
- session을 서버에서 가져와 주입받는 식으로 하고 싶은데 잘안돼서, 현재는 클라이언트에서 세션을 받아 처리하고 있습니다.
- useSession은 내부적으로 React Context를 사용하기 때문에, 클라이언트 컴포넌트에서만 사용 가능합니다. getServerSession(authOptions)로 서버에서 불러올 수 있는데, 그렇게 하더라도 서버와 클라이언트 세션을 동기화시키기는 어려운 것 같습니다.
- 맨처음 렌더링할 때 호출되는 API마다 session이 네트워크 요청이 발생하는데, 한 번만 가져와서 계속 쓰고 싶은데 잘 안되더라구요 😭 한번 가져온 뒤에 interceptor에서 토큰값 넣어준 뒤로는 네트워크 요청이 발생안해서 일단 유지했습니다.

### 회원가입 mutation에서 router 로직 분리

기존의 라우터 로직이 mutation 내부에 들어가 있었습니다. useEffect에서 mutate가 1번만 불려야 하는데, 그렇게 하면 onSuccess, onError가 호출되지 않는 문제가 있었습니다. 해당 부분을 mutate가 아니라 콜백으로 넘겨주고, router 를 UI단의 역할로 처리하는 방식으로 개선하였습니다.