### PR TITLE
[YS-409] 회원가입 로직 QA 반영

### DIFF
--- a/src/apis/config/error.ts
+++ b/src/apis/config/error.ts
@@ -1,0 +1,34 @@
+import { ErrorCode } from './types';
+
+export const SERVER_ERROR_STATUS = 500;
+export const NETWORK_ERROR_STATUS = 5001;
+export const UNHANDLED_ERROR_STATUS = 5002;
+
+interface CustomErrorParams {
+  errorCode: ErrorCode;
+  status: number;
+  message: string;
+}
+
+export class CustomError extends Error {
+  errorCode: string;
+  status: number;
+  message: string;
+
+  constructor({ errorCode, status, message }: CustomErrorParams) {
+    super();
+    this.errorCode = errorCode;
+    this.status = status;
+    this.message = message;
+  }
+}
+
+export class NetworkError extends Error {
+  status = NETWORK_ERROR_STATUS;
+  message = '네트워크가 불안정해요. 다시 시도해주세요!';
+}
+
+export class UnhandledError extends Error {
+  status = UNHANDLED_ERROR_STATUS;
+  message = '예기치 못한 에러가 발생했어요. 관리자에게 문의 바랍니다.';
+}

--- a/src/apis/config/index.ts
+++ b/src/apis/config/index.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
 import { ERROR_MESSAGES } from './constants';
+import { CustomError, NetworkError } from './error';
 import { CustomAxiosError } from './types';
 import { isAuthError, login } from './utils';
-import { CustomError, NetworkError } from './error';
 
 export const API = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,

--- a/src/apis/config/index.ts
+++ b/src/apis/config/index.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { ERROR_MESSAGES } from './constants';
 import { CustomAxiosError } from './types';
 import { isAuthError, login } from './utils';
+import { CustomError, NetworkError } from './error';
 
 export const API = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
@@ -15,7 +16,7 @@ API.interceptors.response.use(
   },
   async (error: CustomAxiosError) => {
     if (error.response && error.response.data.code in ERROR_MESSAGES) {
-      const { data, config } = error.response;
+      const { data, config, status } = error.response;
       const originalRequest = config;
 
       if (isAuthError(data.code)) {
@@ -23,25 +24,28 @@ API.interceptors.response.use(
           axiosInstance: API,
           request: originalRequest,
           code: data.code,
+          status,
         });
       }
 
       if (data.code === 'ME0002') {
         const role = data.message.split(': ').pop()?.trim();
 
-        return Promise.reject({
+        throw new CustomError({
+          status,
+          errorCode: data.code,
           message: ERROR_MESSAGES[data.code](role),
         });
       }
 
-      return Promise.reject({ message: ERROR_MESSAGES[data.code] });
+      throw new CustomError({
+        status,
+        errorCode: data.code,
+        message: ERROR_MESSAGES[data.code],
+      });
     }
 
     // timeout 내에 서버 응답이 없는 경우
-    return Promise.reject({
-      status: 0,
-      code: 'NETWORK_ERROR',
-      message: '네트워크 오류가 발생했습니다. 다시 시도해주세요.',
-    });
+    throw new NetworkError();
   },
 );

--- a/src/apis/config/utils.ts
+++ b/src/apis/config/utils.ts
@@ -4,9 +4,9 @@ import { getSession } from 'next-auth/react';
 import { AuthErrorCode } from './types';
 import { updateAccessToken } from '../login';
 import { ERROR_MESSAGES } from './constants';
+import { CustomError } from './error';
 
 import { loginWithCredentials, logout } from '@/lib/auth-utils';
-import { CustomError } from './error';
 
 export const isAuthError = (code: string) => {
   return (

--- a/src/apis/config/utils.ts
+++ b/src/apis/config/utils.ts
@@ -6,6 +6,7 @@ import { updateAccessToken } from '../login';
 import { ERROR_MESSAGES } from './constants';
 
 import { loginWithCredentials, logout } from '@/lib/auth-utils';
+import { CustomError } from './error';
 
 export const isAuthError = (code: string) => {
   return (
@@ -21,10 +22,12 @@ export const login = async ({
   axiosInstance,
   request,
   code,
+  status,
 }: {
   axiosInstance: AxiosInstance;
   request: InternalAxiosRequestConfig;
   code: AuthErrorCode;
+  status: number;
 }) => {
   try {
     // Next-Auth 세션에서 리프레시 토큰 가져오기
@@ -32,7 +35,11 @@ export const login = async ({
     const refreshToken = session?.refreshToken;
 
     if (!refreshToken) {
-      return Promise.reject({ message: ERROR_MESSAGES[code] });
+      throw new CustomError({
+        status,
+        errorCode: code,
+        message: ERROR_MESSAGES[code],
+      });
     }
 
     const userInfo = await updateAccessToken(refreshToken);

--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -5,7 +5,7 @@ import { API_URL } from '@/constants/url';
 import { ParticipantJoinSchemaType } from '@/schema/join/ParticipantJoinSchema';
 import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
 
-interface UnivAuthCodeResponse {
+export interface UnivAuthCodeResponse {
   isSuccess: boolean;
   message: string;
 }

--- a/src/app/join/components/JoinInput/JoinInput.tsx
+++ b/src/app/join/components/JoinInput/JoinInput.tsx
@@ -19,6 +19,31 @@ import {
 
 import Icon from '@/components/Icon';
 
+const formatDateInput = (inputType: string, value: string) => {
+  if (inputType !== 'date') return value;
+
+  const numbers = value.replace(/\D/g, '');
+
+  if (numbers.length <= 4) {
+    if (numbers.length === 4 && value.includes('.')) return value;
+
+    return numbers;
+  }
+
+  if (numbers.length <= 6) {
+    if (numbers.length === 6 && value.includes('.')) return value;
+
+    const year = numbers.substring(0, 4);
+    const month = numbers.substring(4, 6);
+    return `${year}.${month}`;
+  }
+
+  const year = numbers.substring(0, 4);
+  const month = numbers.substring(4, 6);
+  const day = numbers.substring(6, 8);
+  return `${year}.${month}.${day}`;
+};
+
 interface JoinInputProps<T extends FieldValues> {
   type?: 'input' | 'textarea';
   name: Path<T>;
@@ -34,6 +59,7 @@ interface JoinInputProps<T extends FieldValues> {
   isTip?: boolean;
   isCount?: boolean;
   count?: number;
+  inputType?: 'text' | 'date';
 }
 
 const JoinInput = <T extends FieldValues>({
@@ -51,6 +77,7 @@ const JoinInput = <T extends FieldValues>({
   isTip = true,
   isCount = false,
   count,
+  inputType = 'text',
 }: JoinInputProps<T>) => {
   const [isFocused, setIsFocused] = useState(false);
   const resetButtonRef = useRef<HTMLButtonElement>(null);
@@ -100,6 +127,10 @@ const JoinInput = <T extends FieldValues>({
                   aria-invalid={fieldState.invalid ? true : false}
                   style={{ width: '100%' }}
                   className={joinInput}
+                  onChange={(e) => {
+                    const formattedValue = formatDateInput(inputType, e.target.value);
+                    field.onChange(formattedValue);
+                  }}
                   onFocus={() => setIsFocused(true)}
                   onBlur={(e) => handleBlur(e, field.onBlur)}
                 />

--- a/src/app/join/components/JoinInput/JoinInput.tsx
+++ b/src/app/join/components/JoinInput/JoinInput.tsx
@@ -23,24 +23,25 @@ const formatDateInput = (inputType: string, value: string) => {
   if (inputType !== 'date') return value;
 
   const numbers = value.replace(/\D/g, '');
+  const UNIT = { start: 0, year: 4, month: 6, total: 8 };
 
-  if (numbers.length <= 4) {
-    if (numbers.length === 4 && value.includes('.')) return value;
+  if (numbers.length <= UNIT.year) {
+    if (numbers.length === UNIT.year && value.includes('.')) return value;
 
     return numbers;
   }
 
-  if (numbers.length <= 6) {
-    if (numbers.length === 6 && value.includes('.')) return value;
+  if (numbers.length <= UNIT.month) {
+    if (numbers.length === UNIT.month && value.includes('.')) return value;
 
-    const year = numbers.substring(0, 4);
-    const month = numbers.substring(4, 6);
+    const year = numbers.substring(UNIT.start, UNIT.year);
+    const month = numbers.substring(UNIT.year, UNIT.month);
     return `${year}.${month}`;
   }
 
-  const year = numbers.substring(0, 4);
-  const month = numbers.substring(4, 6);
-  const day = numbers.substring(6, 8);
+  const year = numbers.substring(UNIT.start, UNIT.year);
+  const month = numbers.substring(UNIT.year, UNIT.month);
+  const day = numbers.substring(UNIT.month, UNIT.total);
   return `${year}.${month}.${day}`;
 };
 

--- a/src/app/join/components/Participant/JoinEmailStep/JoinEmailStep.tsx
+++ b/src/app/join/components/Participant/JoinEmailStep/JoinEmailStep.tsx
@@ -79,9 +79,8 @@ const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
           control={control}
           name="contactEmail"
           onClick={handleCheckValidEmail}
-          isLoadingCheck={isLoadingCheck}
+          isLoading={isLoadingCheck}
           isSuccess={isValidEmail}
-          isEmailDuplicateError={isEmailDuplicateError}
           setIsValidToastOpen={setIsValidToastOpen}
           tip="로그인 아이디와 달라도 괜찮아요"
           toast={

--- a/src/app/join/components/Participant/JoinInfoStep/JoinInfoStep.tsx
+++ b/src/app/join/components/Participant/JoinInfoStep/JoinInfoStep.tsx
@@ -78,6 +78,7 @@ const JoinInfoStep = ({ handleSubmit }: JoinInfoStepProps) => {
           maxLength={10}
           tip="나중에 수정할 수 없어요"
           isTip={false}
+          inputType="date"
         />
 
         {/* 거주 지역 */}

--- a/src/app/join/components/Researcher/JoinEmailStep/JoinEmailStep.tsx
+++ b/src/app/join/components/Researcher/JoinEmailStep/JoinEmailStep.tsx
@@ -14,6 +14,7 @@ import useServiceAgreeCheck from '@/app/join/hooks/useServiceAgreeCheck';
 import { joinContentContainer, joinForm } from '@/app/join/JoinPage.css';
 import ButtonInput from '@/components/ButtonInput/ButtonInput';
 import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
+import useVerifyUnivEmail from '@/app/join/hooks/useVerifyUnivEmail';
 
 interface JoinEmailStepProps {
   onNext: () => void;
@@ -34,7 +35,7 @@ const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
   const univEmail = useWatch({ name: 'univEmail', control });
   const contactEmail = useWatch({ name: 'contactEmail', control });
 
-  const [isEmailVerified, setIsEmailVerified] = useState(false);
+  const { isEmailVerified, handleVerifyEmail, handleResetVerifyEmail } = useVerifyUnivEmail();
 
   const handleNextStep = async () => {
     const isValid = await trigger(['oauthEmail', 'contactEmail', 'univEmail']);
@@ -51,10 +52,6 @@ const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
     isEmailVerified &&
     serviceAgreeCheck.isTermOfService &&
     serviceAgreeCheck.isPrivacy;
-
-  const handleVerifyEmail = () => {
-    setIsEmailVerified(true);
-  };
 
   const {
     refetch,
@@ -103,7 +100,11 @@ const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
         />
 
         {/* 학교 메일 인증 */}
-        <UnivAuthInput isEmailVerified={isEmailVerified} handleVerifyEmail={handleVerifyEmail} />
+        <UnivAuthInput
+          isEmailVerified={isEmailVerified}
+          handleVerifyEmail={handleVerifyEmail}
+          handleResetVerifyEmail={handleResetVerifyEmail}
+        />
 
         {/* 동의 체크 항목 */}
         <JoinCheckboxContainer

--- a/src/app/join/components/Researcher/JoinEmailStep/JoinEmailStep.tsx
+++ b/src/app/join/components/Researcher/JoinEmailStep/JoinEmailStep.tsx
@@ -11,10 +11,10 @@ import JoinInput from '../../JoinInput/JoinInput';
 
 import useCheckValidEmailInfoQuery from '@/app/join/hooks/useCheckValidEmailInfoQuery';
 import useServiceAgreeCheck from '@/app/join/hooks/useServiceAgreeCheck';
+import useVerifyUnivEmail from '@/app/join/hooks/useVerifyUnivEmail';
 import { joinContentContainer, joinForm } from '@/app/join/JoinPage.css';
 import ButtonInput from '@/components/ButtonInput/ButtonInput';
 import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
-import useVerifyUnivEmail from '@/app/join/hooks/useVerifyUnivEmail';
 
 interface JoinEmailStepProps {
   onNext: () => void;

--- a/src/app/join/components/Researcher/JoinEmailStep/JoinEmailStep.tsx
+++ b/src/app/join/components/Researcher/JoinEmailStep/JoinEmailStep.tsx
@@ -88,9 +88,8 @@ const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
           control={control}
           name="contactEmail"
           onClick={handleCheckValidEmail}
-          isLoadingCheck={isLoadingCheck}
+          isLoading={isLoadingCheck}
           isSuccess={isSuccess}
-          isEmailDuplicateError={isEmailDuplicateError}
           setIsValidToastOpen={setIsValidToastOpen}
           tip="로그인 아이디와 달라도 괜찮아요"
           toast={

--- a/src/app/join/components/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.css.ts
+++ b/src/app/join/components/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.css.ts
@@ -5,7 +5,6 @@ import { fonts } from '@/styles/fonts.css';
 
 export const univInputWrapper = style({
   position: 'relative',
-  backgroundColor: colors.field01,
   borderRadius: '1rem',
 });
 

--- a/src/app/join/components/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
+++ b/src/app/join/components/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
@@ -65,10 +65,7 @@ const UnivAuthInput = ({ isEmailVerified, handleVerifyEmail }: UnivAuthInputProp
         control={control}
         render={({ field, fieldState }) => {
           const isButtonDisabled =
-            (!isEmailSent && !field.value) ||
-            isEmailVerified ||
-            isLoadingSend ||
-            fieldState.invalid;
+            (!isEmailSent && !field.value) || isLoadingSend || fieldState.invalid;
 
           return (
             <>

--- a/src/app/join/components/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
+++ b/src/app/join/components/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
@@ -24,6 +24,12 @@ interface UnivAuthInputProps {
   handleResetVerifyEmail: () => void;
 }
 
+const getButtonText = (isLoading: boolean, isAuthenticated: boolean) => {
+  if (isLoading) return '전송 중...';
+  if (isAuthenticated) return '수정';
+  return '인증번호 전송';
+};
+
 const UnivAuthInput = ({
   isEmailVerified,
   handleVerifyEmail,
@@ -96,11 +102,7 @@ const UnivAuthInput = ({
                   disabled={isButtonDisabled}
                   onClick={isUnivEmailAuthenticated ? handleClickEdit : handleSendUnivAuthCode}
                 >
-                  {isLoadingSend
-                    ? '전송 중...'
-                    : isUnivEmailAuthenticated
-                    ? '수정'
-                    : '인증번호 전송'}
+                  {getButtonText(isLoadingSend, isUnivEmailAuthenticated)}
                 </button>
               </div>
               {fieldState.error ? (

--- a/src/app/join/components/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
+++ b/src/app/join/components/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
@@ -28,7 +28,7 @@ const UnivAuthInput = ({ isEmailVerified, handleVerifyEmail }: UnivAuthInputProp
 
   const {
     mutate: sendEmail,
-    error: sendError,
+    error: authCodeError,
     isPending: isLoadingSend,
   } = useSendUnivAuthCodeMutation();
 
@@ -46,10 +46,6 @@ const UnivAuthInput = ({ isEmailVerified, handleVerifyEmail }: UnivAuthInputProp
         setIsToastOpen(true);
         startTimer();
       },
-      onError: () => {
-        // TODO: 이미 인증된 유저인 경우에만 verify
-        handleVerifyEmail();
-      },
     });
   };
 
@@ -64,7 +60,6 @@ const UnivAuthInput = ({ isEmailVerified, handleVerifyEmail }: UnivAuthInputProp
         <span>학교 메일 인증</span>
         <span className={required}>*</span>
       </label>
-
       <Controller
         name="univEmail"
         control={control}
@@ -95,8 +90,11 @@ const UnivAuthInput = ({ isEmailVerified, handleVerifyEmail }: UnivAuthInputProp
                   {isLoadingSend ? '전송 중...' : isEmailSent ? '수정' : '인증번호 전송'}
                 </button>
               </div>
-              {fieldState.error && <span className={errorMessage}>{fieldState.error.message}</span>}
-              {sendError && <span className={errorMessage}>{sendError.message}</span>}
+              {fieldState.error ? (
+                <span className={errorMessage}>{fieldState.error.message}</span>
+              ) : (
+                authCodeError && <span className={errorMessage}>{authCodeError.message}</span>
+              )}
             </>
           );
         }}

--- a/src/app/join/hooks/useSendUnivAuthCodeMutation.ts
+++ b/src/app/join/hooks/useSendUnivAuthCodeMutation.ts
@@ -1,10 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
 
-import { sendUnivAuthCode } from '@/apis/login';
+import { CustomError } from '@/apis/config/error';
+import { sendUnivAuthCode, UnivAuthCodeResponse } from '@/apis/login';
 
-// TODO: 이미 인증된 메일일 경우 에러 처리
 const useSendUnivAuthCodeMutation = () => {
-  return useMutation({
+  return useMutation<UnivAuthCodeResponse, CustomError, string>({
     mutationFn: sendUnivAuthCode,
   });
 };

--- a/src/app/join/hooks/useVerifyUnivEmail.ts
+++ b/src/app/join/hooks/useVerifyUnivEmail.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+const useVerifyUnivEmail = () => {
+  const [isEmailVerified, setIsEmailVerified] = useState(false);
+
+  const handleVerifyEmail = () => {
+    setIsEmailVerified(true);
+  };
+
+  const handleResetVerifyEmail = () => {
+    setIsEmailVerified(false);
+  };
+
+  return { isEmailVerified, handleVerifyEmail, handleResetVerifyEmail };
+};
+
+export default useVerifyUnivEmail;

--- a/src/app/user/profile/components/ParticipantUserInfo/ParticipantUserInfo.tsx
+++ b/src/app/user/profile/components/ParticipantUserInfo/ParticipantUserInfo.tsx
@@ -58,9 +58,8 @@ const ParticipantUserInfo = ({ userInfo }: { userInfo: ParticipantResponse }) =>
             control={form.control}
             name="contactEmail"
             onClick={handleCheckValidEmail}
-            isLoadingCheck={isLoadingCheck}
+            isLoading={isLoadingCheck}
             isSuccess={isSuccess}
-            isEmailDuplicateError={isEmailDuplicateError}
             setIsValidToastOpen={setIsValidToastOpen}
             tip="주요 안내 사항을 전달받을 이메일을 입력해 주세요. 이메일 ID와 달라도 괜찮아요"
             toast={

--- a/src/app/user/profile/components/ResearcherUserInfo/ResearcherUserInfo.tsx
+++ b/src/app/user/profile/components/ResearcherUserInfo/ResearcherUserInfo.tsx
@@ -52,9 +52,8 @@ const ResearcherUserInfo = ({ userInfo }: { userInfo: ResearcherResponse }) => {
             control={form.control}
             name="contactEmail"
             onClick={handleCheckValidEmail}
-            isLoadingCheck={isLoadingCheck}
+            isLoading={isLoadingCheck}
             isSuccess={isSuccess}
-            isEmailDuplicateError={isEmailDuplicateError}
             setIsValidToastOpen={setIsValidToastOpen}
             tip="주요 안내 사항을 전달받을 이메일을 입력해 주세요. 이메일 ID와 달라도 괜찮아요"
             toast={

--- a/src/components/ButtonInput/ButtonInput.css.ts
+++ b/src/components/ButtonInput/ButtonInput.css.ts
@@ -40,6 +40,30 @@ export const joinInput = style({
   },
 });
 
+export const inputWrapper = style({
+  position: 'relative',
+  backgroundColor: colors.field01,
+  borderRadius: '1rem',
+});
+
+export const confirmButton = style({
+  ...fonts.label.large.SB14,
+  position: 'absolute',
+  right: '1.2rem',
+  top: '1rem',
+  padding: '0.7rem 1.6rem',
+  borderRadius: '1rem',
+  color: colors.text01,
+  backgroundColor: colors.primaryMint,
+  border: 'none',
+  selectors: {
+    '&:disabled': {
+      color: colors.text02,
+      backgroundColor: colors.field04,
+    },
+  },
+});
+
 export const requiredStar = style({
   color: colors.textAlert,
 });

--- a/src/components/ButtonInput/ButtonInput.tsx
+++ b/src/components/ButtonInput/ButtonInput.tsx
@@ -9,12 +9,9 @@ import {
   requiredStar,
   tipWrapper,
   infoContainer,
+  inputWrapper,
+  confirmButton,
 } from './ButtonInput.css';
-
-import {
-  univAuthButton,
-  univInputWrapper,
-} from '@/app/join/components/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.css';
 
 interface ButtonInputProps<T extends FieldValues> {
   control: Control<T>;
@@ -66,7 +63,7 @@ const ButtonInput = <T extends FieldValues>({
 
           return (
             <>
-              <div className={univInputWrapper}>
+              <div className={inputWrapper}>
                 <input
                   {...field}
                   style={{ width: '100%' }}
@@ -79,7 +76,7 @@ const ButtonInput = <T extends FieldValues>({
                 {isFocused && field.value && (
                   <button
                     type="button"
-                    className={univAuthButton}
+                    className={confirmButton}
                     disabled={isButtonDisabled || isLoading || isSuccess}
                     onClick={onClick}
                     ref={validateButtonRef}

--- a/src/components/ButtonInput/ButtonInput.tsx
+++ b/src/components/ButtonInput/ButtonInput.tsx
@@ -20,9 +20,8 @@ interface ButtonInputProps<T extends FieldValues> {
   control: Control<T>;
   name: Path<T>;
   onClick: () => void;
-  isLoadingCheck: boolean;
+  isLoading: boolean;
   isSuccess: boolean;
-  isEmailDuplicateError: boolean;
   setIsValidToastOpen: (value: boolean) => void;
   toast: React.ReactNode;
   tip?: string;
@@ -32,7 +31,7 @@ const ButtonInput = <T extends FieldValues>({
   control,
   name,
   onClick,
-  isLoadingCheck,
+  isLoading,
   isSuccess,
   toast,
   tip,
@@ -81,11 +80,11 @@ const ButtonInput = <T extends FieldValues>({
                   <button
                     type="button"
                     className={univAuthButton}
-                    disabled={isButtonDisabled || isLoadingCheck || isSuccess}
+                    disabled={isButtonDisabled || isLoading || isSuccess}
                     onClick={onClick}
                     ref={validateButtonRef}
                   >
-                    {isLoadingCheck ? '확인 중...' : '중복 확인'}
+                    {isLoading ? '확인 중...' : '중복 확인'}
                   </button>
                 )}
               </div>

--- a/src/styles/reset.css.ts
+++ b/src/styles/reset.css.ts
@@ -89,31 +89,6 @@ globalStyle('textarea', {
   },
 });
 
-globalStyle(
-  'input:-webkit-autofill, input:-webkit-autofill:hover, input:-webkit-autofill:focus, input:-webkit-autofill:active',
-  {
-    '@layer': {
-      [layers.reset]: {
-        WebkitTextFillColor: '#000',
-        WebkitBoxShadow: '0 0 0px 1000px #fff inset',
-        boxShadow: '0 0 0px 1000px #fff inset',
-        transition: 'background-color 0.3s ease-in-out 0s',
-      },
-    },
-  },
-);
-
-globalStyle('input:autofill, input:autofill:hover, input:autofill:focus, input:autofill:active', {
-  '@layer': {
-    [layers.reset]: {
-      WebkitTextFillColor: '#000',
-      WebkitBoxShadow: '0 0 0px 1000px #fff inset',
-      boxShadow: '0 0 0px 1000px #fff inset',
-      transition: 'background-color 5000s ease-in-out 0s',
-    },
-  },
-});
-
 globalStyle('input::-webkit-inner-spin-button, input::-webkit-outer-spin-button', {
   '@layer': {
     [layers.reset]: {


### PR DESCRIPTION
## Issue Number

<!-- #이슈번호 -->

## As-Is
- 에러 메시지와 헬퍼 텍스트 중복 노출
- 이미 인증한 메일을 입력한 경우, 다시 입력 못함
- 학교 메일 인증 후 회원가입을 안했을 경우, 기존 학교 메일 사용을 못함
<!-- 문제 상황 정의 -->

## To-Be
- 에러 메시지와 헬퍼 텍스트 조건부 노출
- 학교 메일 인증 후 회원가입 안한 유저와 회원가입 한 유저를 구분
- 수정 버튼으로 다른 메일 인증 가능
- 인증된 이메일 수정 시 이메일 인증 안됐다고 판단하여 재검증
- 자동 완성 시 input 흰 배경 제거
- 참여자 회원가입 생년월일 '.' 자동완성 추가
<!-- 변경 사항 -->

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/c2824dd0-c002-4c42-8683-84cf512164ef

## (Optional) Additional Description

생년월일 자동완성 기능을 추가했는데, 입력 후 마우스 커서를 앞으로 이동해 값을 변경할 경우 숫자가 이상하게 변형되는 문제가 있습니다. 입력의 편의성과 중간만 틀릴 확률이 적다는 점에서 우선 반영하겠습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 이메일 인증 상태를 관리하는 커스텀 훅이 추가되었습니다.
    - 에러 처리를 위한 커스텀 에러 클래스 및 상수가 도입되었습니다.
    - 생년월일 입력 필드에 날짜 형식 입력 기능이 추가되었습니다.

- **버그 수정**
    - 이메일 인증 및 중복 확인 버튼의 로딩 및 에러 상태가 명확하게 반영되도록 개선되었습니다.

- **리팩터**
    - 이메일 인증 입력 컴포넌트의 상태 관리 및 에러 처리 로직이 간소화되고 명확해졌습니다.
    - 버튼 입력 컴포넌트의 스타일과 prop 명칭이 일관성 있게 정리되었습니다.

- **스타일**
    - 버튼 입력 및 인증 입력 관련 CSS가 개선되었습니다.
    - input 자동완성(autofill) 관련 CSS가 제거되었습니다.

- **문서화**
    - 일부 인터페이스가 외부에서 사용할 수 있도록 공개되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->