### PR TITLE
[YS-426] 이메일 중복 확인 시 input 내의 버튼이 클릭되지 않는 크로스 브라우징 문제 해결

### DIFF
--- a/src/components/ButtonInput/ButtonInput.tsx
+++ b/src/components/ButtonInput/ButtonInput.tsx
@@ -79,6 +79,7 @@ const ButtonInput = <T extends FieldValues>({
                     className={confirmButton}
                     disabled={isButtonDisabled || isLoading || isSuccess}
                     onClick={onClick}
+                    onMouseDown={(e) => e.preventDefault()}
                     ref={validateButtonRef}
                   >
                     {isLoading ? '확인 중...' : '중복 확인'}


### PR DESCRIPTION
## Issue Number
close #116 
<!-- #이슈번호 -->

## As-Is
- 이메일 중복 확인 시 input 내의 버튼이 Safari에서만 클릭되지 않는 크로스 브라우징 문제
<!-- 문제 상황 정의 -->

## To-Be
- input의 blur 이벤트가 먼저 발생해 클릭 이벤트가 동작하지 않음

<!-- 변경 사항 -->

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

### AS-IS

기존 상태

https://github.com/user-attachments/assets/5afb8dc2-1b9e-427a-9d27-56948aef2551

click 이벤트를 mousedown 이벤트에 걸 경우

https://github.com/user-attachments/assets/b87ae4ce-ed23-422e-be96-a670b914e1da

### TO-BE

click 이벤트 유지 + mousedown 이벤트에 preventDefault 설정

https://github.com/user-attachments/assets/1b9b74c4-1cdd-4a6e-8506-d5cc8ad41e14


## (Optional) Additional Description

### 마우스 이벤트 실행 순서가 다른 크로스 브라우징 이슈 해결

>chrome: mousedown → mouseup → click → `blur`
>safari: mousedown → `blur` → mouseup → click

저는 Chrome에서만 테스트해봤더니 QA가 재현되지 않아 논이슈로 처리했지만 QA측에서 여전히 문제가 발생한다고 하였습니다. 알고보니 저는 Chrome에서 확인하였고, QA 환경은 Safari였습니다. 제 로컬환경에서도 확인해보니 Chrome에서는 동작하지만, Safari에선 동작하지 않는 크로스 브라우징 문제였습니다. 
마우스 이벤트가 동작하기 전에 blur 이벤트가 동작하면서 중복 확인 버튼이 사라지는 문제였습니다. input 태그의 포커싱이 사라지면서 setIsFocused(false)로 설정되고, 버튼은 isFocused 상태에 따라 조건부 렌더링됩니다. 그래서 blur가 클릭보다 먼저 이벤트가 발생하면 클릭이 발생하지 않게 됩니다. 정리하자면,

🚨문제 상황: 중복 확인 버튼의 "click 이벤트"가 input 필드의 "blur 이벤트"보다 늦게 실행되어 클릭 이벤트 핸들러가 동작하지 않습니다.

❌ 해결 1: onClick 대신 onMouseDown에 클릭 이벤트를 등록합니다. 문제는 해결되지만, 약간의 문제가 있습니다. 보통 클릭을 하려다가 마우스를 떼지 않고 밖으로 나가면 동작을 취소하는 방식을 해본 적 있을텐데, mousedown은 마우스가 클릭되자마자 동작하기 때문에 해당 동작이 불가능해집니다. 사용자 경험 측면에 악영향을 미칩니다.

✅ 해결 2: onMouseDown에 e.preventDefault()로 브라우저 기본동작을 막습니다. mouseDown에 브라우저 기본동작은 포커싱을 mouseDown한 요소로 이동시키는 것입니다. 즉, input 태그의 blur 동작을 막으므로 click이벤트가 발생하여 정상 동작하게 됩니다. 해결 1에서 본 마우스 드래그 취소 동작도 동일하게 동작합니다.



https://stackoverflow.com/questions/17769005/onclick-and-onblur-ordering-issue

