### PR TITLE
[YS-427] 회원 탈퇴 시 기타 입력이 필수로 잡히는 오류 해결

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -19,7 +19,7 @@ export interface ValidateContactEmailParams {
 
 export interface LeaveUserParams {
   reasonType: ReasonType;
-  reason: string | null;
+  reason?: string;
 }
 
 export const updateParticipantInfo = async (params: ParticipantUpdateSchemaType) => {

--- a/src/app/user/leave/hooks/useLeaveForm.ts
+++ b/src/app/user/leave/hooks/useLeaveForm.ts
@@ -21,16 +21,18 @@ const useLeaveForm = () => {
   const reason = useWatch({ name: 'reason', control });
 
   const reasonCondition =
-    reasonType !== 'OTHER' || (reasonType === 'OTHER' && reason.trim().length >= 1);
+    reasonType !== 'OTHER' || (reasonType === 'OTHER' && !!reason && reason.trim().length >= 1);
   const isValidLeave = reasonType && reasonCondition && Object.keys(formState.errors).length === 0;
 
   const onSubmit = (data: LeaveSchemaType) => {
     const formattedData = {
       reasonType: data.reasonType,
-      reason: data.reason === '' ? null : data.reason,
+      reason: data.reason,
     };
 
-    leave(formattedData, {
+    const submitData = data.reason !== '' ? formattedData : { reasonType: data.reasonType };
+
+    leave(submitData, {
       onSuccess: () => {
         signOut({ callbackUrl: '/user/success' });
       },

--- a/src/schema/profile/LeaveSchema.ts
+++ b/src/schema/profile/LeaveSchema.ts
@@ -3,21 +3,26 @@ import { z } from 'zod';
 export type LeaveSchemaType = z.infer<ReturnType<typeof LeaveSchema>>;
 
 const LeaveSchema = () => {
-  return z.object({
+  const reasonSchema = z.object({
     reasonType: z.enum([
       'RESEARCH_STOPPED',
       'SECURITY_CONCERN',
       'NO_NECESSARY_FUNCTION',
       'TOO_MANY_EMAILS',
       'INCONVENIENT_SITE',
-      'OTHER',
     ]),
+    reason: z.string().optional(),
+  });
 
+  const otherReasonSchema = z.object({
+    reasonType: z.literal('OTHER'),
     reason: z
       .string()
       .min(1, { message: '최소 1자 이상 입력해 주세요' })
       .max(300, { message: '최대 300자 이하로 입력해 주세요' }),
   });
+
+  return z.discriminatedUnion('reasonType', [reasonSchema, otherReasonSchema]);
 };
 
 export default LeaveSchema;


### PR DESCRIPTION
## Issue Number
close #118 
<!-- #이슈번호 -->

## As-Is
- 기타가 아닌 다른 객관식 선택을 해도 기타 사유 유효성 검증이 적용되어 탈퇴가 막힘
<!-- 문제 상황 정의 -->

## To-Be
- 기타를 선택할 경우에만 유효성 검증되도록 discriminatedUnion 적용
<!-- 변경 사항 -->

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description

### discriminatedUnion

**객체의 특정 필드 값에 따라 다른 스키마로 유효성 검증을 할 수 있는 기능** 입니다.

```ts
z.discriminatedUnion(discriminator, schemas)
```

`discriminator`: 어떤 스키마를 사용할지 결정하는 필드명 (문자열)
`schemas`: 가능한 스키마들의 배열

1. discriminator를 입력 데이터에서 확인
2. 이 값과 일치하는 스키마를 schemas 배열에서 찾기
3. 일치하는 스키마를 사용하여 유효성 검증

각 스키마는 discriminator 필드를 리터럴 타입으로 정의해야 어떤 스키마를 사용할지 명확하게 결정할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 회원 탈퇴 사유 입력란에서 '기타'를 선택할 경우, 사유가 반드시 입력되어야 하며 1~300자 이내로 입력하도록 검증이 강화되었습니다.
  - 기타 이외의 사유 선택 시, 사유 입력란은 선택적으로 입력할 수 있습니다.

- **리팩터**
  - 회원 탈퇴 시 사유 입력 필드의 동작과 유효성 검사가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->