### PR TITLE
[YS-374] 밀린 디자인 화면 반영 및 QA 수정

### DIFF
--- a/src/app/my-posts/MyPostsPage.css.ts
+++ b/src/app/my-posts/MyPostsPage.css.ts
@@ -6,7 +6,7 @@ export const myPostsLayoutContainer = style({
   width: 'fit-content',
   margin: '0 auto',
   backgroundColor: colors.field01,
-  paddingBottom: '2.6rem',
+  paddingBottom: '5.6rem',
 });
 
 export const myPostsLayout = style({

--- a/src/app/my-posts/components/MyPostsContainer/MyPostsContainer.tsx
+++ b/src/app/my-posts/components/MyPostsContainer/MyPostsContainer.tsx
@@ -2,17 +2,9 @@
 
 import { useState } from 'react';
 
-import {
-  myPostContainerLayout,
-  myPostsHeaderContainer,
-  myPostsHeaderText,
-  postsSorting,
-} from './MyPostsContainer.css';
 import useMyPostsQuery from '../../hooks/useMyPostsQuery';
+import MyPostsHeader from '../MyPostsHeader/MyPostHeader';
 import MyPostsTable from '../MyPostsTable/MyPostsTable';
-
-import Icon from '@/components/Icon';
-import { colors } from '@/styles/colors';
 
 export const PAGE_SIZE = 10;
 
@@ -31,27 +23,13 @@ const MyPostsContainer = () => {
   };
 
   return (
-    <div className={myPostContainerLayout}>
-      <div className={myPostsHeaderContainer}>
-        {!myPostAPIResponse.isError && (
-          <>
-            <h2 className={myPostsHeaderText}>내가 작성한 글</h2>
-            {myPostAPIResponse.data?.content && myPostAPIResponse.data.content.length > 0 && (
-              <div className={postsSorting} onClick={toggleOrder} style={{ cursor: 'pointer' }}>
-                <p>{order === 'DESC' ? '최신순' : '오래된 순'}</p>
-                <Icon
-                  icon="ArrowSorting"
-                  width={20}
-                  height={20}
-                  color={colors.icon04}
-                  rotate={order === 'DESC' ? 0 : 180}
-                />
-              </div>
-            )}
-          </>
-        )}
-      </div>
-
+    <div>
+      <MyPostsHeader
+        isError={!!myPostAPIResponse.isError}
+        hasPosts={!!myPostAPIResponse.data?.content.length}
+        order={order}
+        toggleOrder={toggleOrder}
+      />
       <MyPostsTable
         myPostAPIResponse={myPostAPIResponse}
         currentPage={currentPage}

--- a/src/app/my-posts/components/MyPostsContainer/MyPostsContainer.tsx
+++ b/src/app/my-posts/components/MyPostsContainer/MyPostsContainer.tsx
@@ -33,18 +33,22 @@ const MyPostsContainer = () => {
   return (
     <div className={myPostContainerLayout}>
       <div className={myPostsHeaderContainer}>
-        <h2 className={myPostsHeaderText}>내가 작성한 글</h2>
-        {myPostAPIResponse.data?.content && myPostAPIResponse.data.content.length > 0 && (
-          <div className={postsSorting} onClick={toggleOrder} style={{ cursor: 'pointer' }}>
-            <p>{order === 'DESC' ? '최신순' : '오래된 순'}</p>
-            <Icon
-              icon="ArrowSorting"
-              width={20}
-              height={20}
-              color={colors.icon04}
-              rotate={order === 'DESC' ? 0 : 180}
-            />
-          </div>
+        {!myPostAPIResponse.isError && (
+          <>
+            <h2 className={myPostsHeaderText}>내가 작성한 글</h2>
+            {myPostAPIResponse.data?.content && myPostAPIResponse.data.content.length > 0 && (
+              <div className={postsSorting} onClick={toggleOrder} style={{ cursor: 'pointer' }}>
+                <p>{order === 'DESC' ? '최신순' : '오래된 순'}</p>
+                <Icon
+                  icon="ArrowSorting"
+                  width={20}
+                  height={20}
+                  color={colors.icon04}
+                  rotate={order === 'DESC' ? 0 : 180}
+                />
+              </div>
+            )}
+          </>
         )}
       </div>
 

--- a/src/app/my-posts/components/MyPostsHeader/MyPostHeader.tsx
+++ b/src/app/my-posts/components/MyPostsHeader/MyPostHeader.tsx
@@ -1,0 +1,35 @@
+import { myPostsHeaderContainer, myPostsHeaderText, postsSorting } from './MyPostsHeader.css';
+
+import Icon from '@/components/Icon';
+import { colors } from '@/styles/colors';
+
+interface MyPostsHeaderProps {
+  isError: boolean;
+  hasPosts: boolean;
+  order: 'DESC' | 'ASC';
+  toggleOrder: () => void;
+}
+
+const MyPostsHeader = ({ isError, hasPosts, order, toggleOrder }: MyPostsHeaderProps) => {
+  if (isError) return null;
+
+  return (
+    <div className={myPostsHeaderContainer}>
+      <h2 className={myPostsHeaderText}>내가 작성한 글</h2>
+      {hasPosts && (
+        <div className={postsSorting} onClick={toggleOrder} style={{ cursor: 'pointer' }}>
+          <p>{order === 'DESC' ? '최신순' : '오래된 순'}</p>
+          <Icon
+            icon="ArrowSorting"
+            width={20}
+            height={20}
+            color={colors.icon04}
+            rotate={order === 'DESC' ? 0 : 180}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MyPostsHeader;

--- a/src/app/my-posts/components/MyPostsHeader/MyPostsHeader.css.ts
+++ b/src/app/my-posts/components/MyPostsHeader/MyPostsHeader.css.ts
@@ -1,0 +1,26 @@
+import { style } from '@vanilla-extract/css';
+
+import { colors } from '@/styles/colors';
+import { fonts } from '@/styles/fonts.css';
+
+export const myPostsHeaderContainer = style({
+  display: 'flex',
+  flexFlow: 'row nowrap',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const myPostsHeaderText = style({
+  ...fonts.title.medium.SB20,
+  marginBottom: '2rem',
+  marginTop: '1.2rem',
+});
+
+export const postsSorting = style({
+  ...fonts.label.large.SB14,
+  color: colors.text03,
+  display: 'flex',
+  flexFlow: 'row nowrap',
+  alignItems: 'center',
+  gap: '0.4rem',
+});

--- a/src/app/my-posts/components/MyPostsTable/MyPostsTable.css.ts
+++ b/src/app/my-posts/components/MyPostsTable/MyPostsTable.css.ts
@@ -55,6 +55,27 @@ globalStyle(`${textAlignRight} div`, {
   textAlign: 'right',
 });
 
+export const tableInfoRow = style({
+  ...fonts.body.normal.R16,
+});
+
+export const tableBody = style({});
+
+export const tableRow = style({});
+
+globalStyle(`${tableBody} > ${tableRow} > td`, {
+  paddingTop: '0.4rem',
+  paddingBottom: '0.4rem',
+});
+
+globalStyle(
+  `${tableBody} > ${tableRow}:first-child > td, ${tableBody} > ${tableRow}:last-child > td`,
+  {
+    paddingTop: '0',
+    paddingBottom: '0',
+  },
+);
+
 export const tableEmptyViewLayout = style({
   width: '100%',
   margin: '0 auto',

--- a/src/app/my-posts/components/MyPostsTable/MyPostsTable.tsx
+++ b/src/app/my-posts/components/MyPostsTable/MyPostsTable.tsx
@@ -24,6 +24,9 @@ import {
   tableEmptyViewLayout,
   emptyTitle,
   emptySubTitle,
+  tableInfoRow,
+  tableBody,
+  tableRow,
 } from './MyPostsTable.css';
 import { MyPosts, UseMyPostsQueryResponse } from '../../hooks/useMyPostsQuery';
 import useUpdateRecruitStatusMutation from '../../hooks/useUpdateRecruitStatusMutation';
@@ -134,13 +137,13 @@ const MyPostsTable = ({
     {
       accessorKey: 'uploadDate',
       header: '게시 날짜',
-      cell: ({ row }) => <div>{row.getValue('uploadDate')}</div>,
+      cell: ({ row }) => <div className={tableInfoRow}>{row.getValue('uploadDate')}</div>,
       size: 108,
     },
     {
       accessorKey: 'views',
       header: '조회수',
-      cell: ({ row }) => <div>{row.getValue('views')}</div>,
+      cell: ({ row }) => <div className={tableInfoRow}>{row.getValue('views')}</div>,
       size: 80,
     },
     {
@@ -159,7 +162,7 @@ const MyPostsTable = ({
             <Icon icon="ToggleOn" width={32} height={18} cursor="pointer" />
           </button>
         ) : (
-          <Icon icon="ToggleOff" width={32} height={18} />
+          <Icon icon="ToggleOff" width={32} height={18} cursor="notAllowed" />
         );
       },
       size: 68,
@@ -232,8 +235,7 @@ const MyPostsTable = ({
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => {
-                  const isLeftAlign =
-                    header.column.id === 'title' || header.column.id === 'recruitStatus';
+                  const isLeftAlign = header.column.id === 'title';
                   return (
                     <TableHead
                       key={header.id}
@@ -249,14 +251,13 @@ const MyPostsTable = ({
               </TableRow>
             ))}
           </TableHeader>
-          <TableBody>
+          <TableBody className={tableBody}>
             <tr style={{ height: '1.2rem' }} />
             {table.getRowModel().rows.length ? (
               table.getRowModel().rows.map((row) => (
-                <TableRow key={row.id}>
+                <TableRow key={row.id} className={tableRow}>
                   {row.getVisibleCells().map((cell) => {
-                    const isLeftAlign =
-                      cell.column.id === 'title' || cell.column.id === 'recruitStatus';
+                    const isLeftAlign = cell.column.id === 'title';
                     return (
                       <TableCell
                         key={cell.id}

--- a/src/app/my-posts/components/Pagination/Pagination.css.ts
+++ b/src/app/my-posts/components/Pagination/Pagination.css.ts
@@ -16,7 +16,8 @@ export const paginationContent = style({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '0.4rem',
+  justifyContent: 'center',
+  gap: '0.8rem',
 });
 
 export const paginationItem = style({
@@ -26,11 +27,15 @@ export const paginationItem = style({
 });
 
 export const paginationLink = style({
-  padding: '0.8rem 1.2rem',
-  borderRadius: '0.4rem',
+  width: '2.4rem',
+  height: '2.4rem',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
   textDecoration: 'none',
   fontSize: '1.4rem',
   cursor: 'pointer',
+  borderRadius: '0.8rem',
   selectors: {
     '&:hover': {
       backgroundColor: colors.field02,
@@ -46,13 +51,11 @@ export const active = style({
 export const paginationPrevious = style({
   display: 'flex',
   alignItems: 'center',
-  gap: '0.4rem',
 });
 
 export const paginationNext = style({
   display: 'flex',
   alignItems: 'center',
-  gap: '0.4rem',
 });
 
 export const paginationEllipsis = style({

--- a/src/app/my-posts/components/PostActionsPopover/PostActionsPopover.css.ts
+++ b/src/app/my-posts/components/PostActionsPopover/PostActionsPopover.css.ts
@@ -6,8 +6,8 @@ import { zIndex } from '@/styles/zIndex';
 
 export const postsActionsPopoverContainer = style({
   marginLeft: '-1.6rem',
-  height: '2rem',
-  verticalAlign: 'middle',
+  height: '1.6rem',
+  width: '1.6rem',
 });
 
 export const postsActionsPopoverContent = style({

--- a/src/app/my-posts/components/PostActionsPopover/PostActionsPopover.tsx
+++ b/src/app/my-posts/components/PostActionsPopover/PostActionsPopover.tsx
@@ -36,7 +36,6 @@ const PostActionsPopover = ({ experimentPostId }: PostActionsPopoverProps) => {
   const queryClient = useQueryClient();
   const { mutate: deleteExperimentPostMutation } = useDeleteExperimentPostMutation();
 
-  // todo 공고 수정
   const handleEdit = () => {
     setPopoverOpen(false);
     router.push(`/edit/${experimentPostId}`);
@@ -67,7 +66,7 @@ const PostActionsPopover = ({ experimentPostId }: PostActionsPopoverProps) => {
       <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
         <PopoverTrigger asChild>
           <button aria-label="수정 / 삭제 팝오버 열기" className={postsActionsPopoverContainer}>
-            <Icon role="button" icon="MenuDots" width={20} height={20} cursor="pointer" />
+            <Icon role="button" icon="MenuDots" width={12} height={12} cursor="pointer" />
           </button>
         </PopoverTrigger>
         <PopoverContent

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -14,7 +14,6 @@ function makeQueryClient() {
 }
 
 let browserQueryClient: QueryClient | undefined = undefined;
-
 function getQueryClient() {
   if (isServer) {
     return makeQueryClient();

--- a/src/app/upload/components/DatePickerForm/DatePickerForm.css.ts
+++ b/src/app/upload/components/DatePickerForm/DatePickerForm.css.ts
@@ -95,7 +95,6 @@ export const popoverLayout = style({
 export const datepickerCustomClass = style({});
 
 globalStyle(`.${datepickerCustomClass} .rdp-months`, {
-  // width: '40rem',
   position: 'relative',
   paddingTop: '1.2rem',
 });
@@ -176,6 +175,7 @@ globalStyle(`.${datepickerCustomClass} .rdp-weekdays`, {
 
 globalStyle(`.${datepickerCustomClass} .rdp-weekdays th`, {
   ...fonts.label.medium.M13,
+  verticalAlign: 'middle',
 });
 
 globalStyle(`.${datepickerCustomClass} .rdp-weekdays th:first-of-type`, {
@@ -228,4 +228,19 @@ globalStyle(`.${datepickerCustomClass} .rdp-range_end .rdp-day_button`, {
 
 globalStyle(`.${datepickerCustomClass} .rdp-selected`, {
   ...fonts.body.normal.M16,
+});
+
+globalStyle(`.${datepickerCustomClass} .rdp-day.single-day-selected`, {
+  position: 'relative',
+});
+
+globalStyle(`.${datepickerCustomClass} .rdp-day.single-day-selected::after`, {
+  ...fonts.label.small.M12,
+  content: '"하루 진행"',
+  position: 'absolute',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  fontSize: '1.2rem',
+  color: colors.textPrimary,
+  whiteSpace: 'nowrap',
 });

--- a/src/app/upload/components/DatePickerForm/DatePickerForm.css.ts
+++ b/src/app/upload/components/DatePickerForm/DatePickerForm.css.ts
@@ -230,17 +230,38 @@ globalStyle(`.${datepickerCustomClass} .rdp-selected`, {
   ...fonts.body.normal.M16,
 });
 
-globalStyle(`.${datepickerCustomClass} .rdp-day.single-day-selected`, {
-  position: 'relative',
-});
+globalStyle(
+  `.${datepickerCustomClass} .rdp-day.single-day-selected,
+  .${datepickerCustomClass} .rdp-day.start-day-selected,
+  .${datepickerCustomClass} .rdp-day.end-day-selected`,
+  {
+    position: 'relative',
+  },
+);
+
+globalStyle(
+  `.${datepickerCustomClass} .rdp-day.single-day-selected::after,
+  .${datepickerCustomClass} .rdp-day.start-day-selected::after,
+  .${datepickerCustomClass} .rdp-day.end-day-selected::after`,
+  {
+    ...fonts.label.small.M12,
+    position: 'absolute',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    fontSize: '1.2rem',
+    color: colors.textPrimary,
+    whiteSpace: 'nowrap',
+  },
+);
 
 globalStyle(`.${datepickerCustomClass} .rdp-day.single-day-selected::after`, {
-  ...fonts.label.small.M12,
   content: '"하루 진행"',
-  position: 'absolute',
-  left: '50%',
-  transform: 'translateX(-50%)',
-  fontSize: '1.2rem',
-  color: colors.textPrimary,
-  whiteSpace: 'nowrap',
+});
+
+globalStyle(`.${datepickerCustomClass} .rdp-day.start-day-selected::after`, {
+  content: '"시작일"',
+});
+
+globalStyle(`.${datepickerCustomClass} .rdp-day.end-day-selected::after`, {
+  content: '"종료일"',
 });

--- a/src/app/upload/components/DatePickerForm/DatePickerForm.tsx
+++ b/src/app/upload/components/DatePickerForm/DatePickerForm.tsx
@@ -177,9 +177,23 @@ const DatePickerForm = forwardRef<HTMLInputElement, DatePickerFormProps>(
                     selectedDates.from.getTime() === selectedDates.to.getTime()
                       ? [selectedDates.from]
                       : [],
+                  startDay:
+                    selectedDates.from &&
+                    selectedDates.to &&
+                    selectedDates.from.getTime() !== selectedDates.to.getTime()
+                      ? [selectedDates.from]
+                      : [],
+                  endDay:
+                    selectedDates.from &&
+                    selectedDates.to &&
+                    selectedDates.from.getTime() !== selectedDates.to.getTime()
+                      ? [selectedDates.to]
+                      : [],
                 }}
                 modifiersClassNames={{
                   singleDay: 'single-day-selected',
+                  startDay: 'start-day-selected',
+                  endDay: 'end-day-selected',
                 }}
               />
             </Popover.Content>

--- a/src/app/upload/components/DatePickerForm/DatePickerForm.tsx
+++ b/src/app/upload/components/DatePickerForm/DatePickerForm.tsx
@@ -170,6 +170,17 @@ const DatePickerForm = forwardRef<HTMLInputElement, DatePickerFormProps>(
                 className={datepickerCustomClass}
                 captionLayout="dropdown-months"
                 showOutsideDays
+                modifiers={{
+                  singleDay:
+                    selectedDates.from &&
+                    selectedDates.to &&
+                    selectedDates.from.getTime() === selectedDates.to.getTime()
+                      ? [selectedDates.from]
+                      : [],
+                }}
+                modifiersClassNames={{
+                  singleDay: 'single-day-selected',
+                }}
               />
             </Popover.Content>
           </Popover.Portal>

--- a/src/app/upload/components/DescriptionSection/DescriptionSection.tsx
+++ b/src/app/upload/components/DescriptionSection/DescriptionSection.tsx
@@ -210,7 +210,7 @@ const DescriptionSection = ({ images, setImages }: DescriptionSectionProps) => {
 
           {/* 에러 메시지  */}
           {errors.content?.message && (
-            <p className={formMessage} style={{ marginTop: '-1.2rem' }}>
+            <p className={formMessage} style={{ marginTop: '-0.2rem' }}>
               {errors.content.message}
             </p>
           )}

--- a/src/app/upload/components/InputForm/InputForm.css.ts
+++ b/src/app/upload/components/InputForm/InputForm.css.ts
@@ -61,6 +61,7 @@ export const textSubMessageLayout = styleVariants({
     justifyContent: 'space-between',
     alignItems: 'center',
     marginTop: '0.4rem',
+    marginBottom: '0.8rem',
   },
   noCounter: {
     display: 'flex',

--- a/src/app/upload/components/OutlineSection/OutlineSection.css.ts
+++ b/src/app/upload/components/OutlineSection/OutlineSection.css.ts
@@ -78,7 +78,7 @@ export const disabledInput = style({
   width: '100%',
   maxWidth: '45.2rem',
   height: '4.8rem',
-  padding: '10px',
+  padding: '1.6rem',
   borderRadius: '1.2rem',
   outline: 'none',
   border: `0.1rem solid ${colors.line01}`,

--- a/src/components/Icon/icons/MenuDots.tsx
+++ b/src/components/Icon/icons/MenuDots.tsx
@@ -5,13 +5,14 @@ import { colors } from '@/styles/colors';
 function MenuDots(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
-      width="4"
+      width="3"
       height="12"
       viewBox="0 0 4 12"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       role="img"
       aria-label="메뉴 더보기"
+      transform="translate(0,-1)"
       {...props}
     >
       <path

--- a/src/components/Icon/icons/ToggleOff.tsx
+++ b/src/components/Icon/icons/ToggleOff.tsx
@@ -5,17 +5,17 @@ import { colors } from '@/styles/colors';
 function ToggleOff(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
-      width="42"
-      height="38"
-      viewBox="0 -4 42 38"
+      width={props.width ?? '32'}
+      height={props.height ?? '38'}
+      viewBox="0 -2 32 38"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       role="img"
       aria-label="토글 스위치 꺼짐"
-      transform="translate(-2, 0)"
+      transform="translate(10, 1)"
     >
       <rect y="6" width="32" height="18" rx="9" fill={props.color || colors.field05} />
-      <g filter="url(#filter0_d_3107_24218)">
+      <g>
         <circle cx="9" cy="15" r="7" fill="white" />
       </g>
       <defs>

--- a/src/components/Icon/icons/ToggleOn.tsx
+++ b/src/components/Icon/icons/ToggleOn.tsx
@@ -5,17 +5,17 @@ import { colors } from '@/styles/colors';
 function ToggleOn(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
-      width="42"
-      height="38"
-      viewBox="0 -4 42 38"
+      width={props.width ?? '32'}
+      height={props.height ?? '38'}
+      viewBox="0 -4 32 38"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       role="img"
       aria-label="토글 스위치 켜짐"
-      transform="translate(0,3)"
+      transform="translate(5,3)"
     >
       <rect y="6" width="32" height="18" rx="9" fill={props.color || colors.primaryMint} />
-      <g filter="url(#filter0_d_3107_24227)">
+      <g>
         <circle cx="23" cy="15" r="7" fill="white" />
       </g>
       <defs>

--- a/src/components/Icon/icons/ToggleOn.tsx
+++ b/src/components/Icon/icons/ToggleOn.tsx
@@ -12,7 +12,7 @@ function ToggleOn(props: SVGProps<SVGSVGElement>) {
       xmlns="http://www.w3.org/2000/svg"
       role="img"
       aria-label="토글 스위치 켜짐"
-      transform="translate(5,3)"
+      transform="translate(4,3)"
     >
       <rect y="6" width="32" height="18" rx="9" fill={props.color || colors.primaryMint} />
       <g>


### PR DESCRIPTION
## Issue Number

<!-- #이슈번호 -->

close #79 

## As-Is

디자인 QA
- 내가 작성한 글 디자인 QA
- 공고 등록 및 수정 QA

<!-- 문제 상황 정의 -->

## To-Be
디자인 QA 반영
- 작성 글 테이블 위치, 여백, 요소 크기 수정 / 작성 글 EmptyView 수정 등
- datePicker -> 하루 진행 / 시작일 / 종료일 텍스트 추가, 에러메세지 위치 수정, input padding 수정 등

<!-- 변경 사항 -->

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

<img width="1230" alt="image" src="https://github.com/user-attachments/assets/f37a3791-b2f6-4f3a-a875-5ee068664675" />
<img width="487" alt="image" src="https://github.com/user-attachments/assets/7c94adbf-ddc0-48bc-b243-76c8bacd27e9" />



## (Optional) Additional Description

브랜치 관리를 하다가 이전 작업을 날렸더라고요.. ^.^ 호호.. 새로 시작했습니다.
이 PR은 대부분 디자인 QA 반영이라 스타일 코드 변경 위주입니다. 가볍게 넘기셔도 괜찮습니다!
디자인 QA 먼저 해결하였고 해결 못한 기능 위주 QA가 있는데 해당 내용은 새로 이슈 파서 진행하겠습니다. 

<br/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **스타일**
    - 내 글 목록, 테이블, 페이지네이션, 포스트 액션 등 다양한 컴포넌트의 여백, 정렬, 폰트, 아이콘 크기 등 스타일이 개선되었습니다.
    - 날짜 선택기에서 선택된 날짜에 "하루 진행", "시작일", "종료일" 라벨이 시각적으로 표시됩니다.
- **버그 수정**
    - 내 글 목록에서 오류 발생 시 헤더와 정렬 UI가 보이지 않도록 변경되었습니다.
- **기능 개선**
    - 토글 및 메뉴 아이콘이 더 일관된 크기와 정렬로 표시됩니다.
    - 날짜 선택기의 선택 구간이 더 명확하게 구분됩니다.
    - 내 글 목록 헤더가 별도 컴포넌트로 분리되어 가독성과 유지보수성이 향상되었습니다.
    - 게시글 정렬 기능의 UI가 개선되어 사용자가 현재 정렬 상태를 쉽게 확인하고 변경할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->