### PR TITLE
[YS-442] 바텀시트와 이메일 입력 페이지 사이의 상태 공유를 위해 Form Schema 개선

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,10 @@
 ## Issue Number
-
 <!-- #이슈번호 -->
 
 ## As-Is
-
 <!-- 문제 상황 정의 -->
 
 ## To-Be
-
 <!-- 변경 사항 -->
 
 ## Check List

--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -2,7 +2,7 @@ import { fetchClient } from './config/fetchClient';
 import { ValidateContactEmailParams } from './user';
 
 import { API_URL } from '@/constants/url';
-import { ParticipantJoinSchemaType } from '@/schema/join/ParticipantJoinSchema';
+import { ParticipantJoinSubmitSchemaType } from '@/schema/join/ParticipantJoinSchema';
 import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
 import { Role } from '@/types/user';
 
@@ -92,7 +92,7 @@ export const joinResearcher = async (params: ResearcherJoinSchemaType) => {
   return await fetchClient.post<JoinResponse>(API_URL.joinResearcher, { body: params });
 };
 
-export const joinParticipant = async (params: ParticipantJoinSchemaType) => {
+export const joinParticipant = async (params: ParticipantJoinSubmitSchemaType) => {
   return await fetchClient.post<JoinResponse>(API_URL.joinParticipant, { body: params });
 };
 

--- a/src/app/join/hooks/useParticipantJoin.ts
+++ b/src/app/join/hooks/useParticipantJoin.ts
@@ -3,8 +3,10 @@ import { useForm } from 'react-hook-form';
 
 import useParticipantJoinMutation from '../hooks/useParticipantJoinMutation';
 
-import ParticipantJoinSchema, {
+import {
+  ParticipantJoinSchema,
   ParticipantJoinSchemaType,
+  ParticipantJoinSubmitSchema,
 } from '@/schema/join/ParticipantJoinSchema';
 
 interface UseParticipantJoinProps {
@@ -28,6 +30,8 @@ export const useParticipantJoin = ({ onSuccess, initialValues }: UseParticipantJ
       },
       adConsent: false,
       matchConsent: false,
+      isTermOfService: false,
+      isPrivacy: false,
     },
   });
 
@@ -35,9 +39,10 @@ export const useParticipantJoin = ({ onSuccess, initialValues }: UseParticipantJ
 
   const handleParticipantSubmit = () => {
     const formData = participantMethods.getValues();
+    const submitData = ParticipantJoinSubmitSchema().parse(formData);
 
-    const formattedData = {
-      ...formData,
+    const formattedSubmitData = {
+      ...submitData,
       birthDate: formData.birthDate.replaceAll('.', '-'),
       additionalAddressInfo:
         Object.values(formData.additionalAddressInfo ?? {}).filter(Boolean).length > 0
@@ -45,7 +50,7 @@ export const useParticipantJoin = ({ onSuccess, initialValues }: UseParticipantJ
           : null,
     };
 
-    joinParticipant(formattedData, {
+    joinParticipant(formattedSubmitData, {
       onSuccess,
     });
   };

--- a/src/app/join/mobile/Participant/ContactEmailStep/ContactEmailStep.tsx
+++ b/src/app/join/mobile/Participant/ContactEmailStep/ContactEmailStep.tsx
@@ -38,6 +38,8 @@ const ContactEmailStep = ({ onNext, provider, oauthEmail }: ContactEmailStepProp
   const { control } = methods;
 
   const contactEmail = useWatch({ name: 'contactEmail', control });
+  const isTermOfService = useWatch({ name: 'isTermOfService', control });
+  const isPrivacy = useWatch({ name: 'isPrivacy', control });
 
   const {
     refetch,
@@ -50,6 +52,8 @@ const ContactEmailStep = ({ onNext, provider, oauthEmail }: ContactEmailStepProp
   const [isShowNextButton, setIsShowNextButton] = useState(false);
 
   const { open, close } = useOverlay();
+
+  const isValidCheck = isTermOfService && isPrivacy;
 
   const handleCheckValidEmail = async () => {
     const query = await refetch();
@@ -109,7 +113,7 @@ const ContactEmailStep = ({ onNext, provider, oauthEmail }: ContactEmailStepProp
             variant="primary"
             size="small"
             height="56px"
-            disabled={!isEmailValid}
+            disabled={!isEmailValid || !isValidCheck}
             onClick={onNext}
           >
             다음

--- a/src/app/join/mobile/Participant/ContactEmailStep/ContactEmailStep.tsx
+++ b/src/app/join/mobile/Participant/ContactEmailStep/ContactEmailStep.tsx
@@ -49,18 +49,19 @@ const ContactEmailStep = ({ onNext, provider, oauthEmail }: ContactEmailStepProp
   } = useCheckValidEmailInfoQuery(contactEmail);
 
   const [isValidToastOpen, setIsValidToastOpen] = useState(false);
-  const [isShowNextButton, setIsShowNextButton] = useState(false);
+  const [hasValidatedEmail, setHasValidatedEmail] = useState(false);
 
   const { open, close } = useOverlay();
 
   const isValidCheck = isTermOfService && isPrivacy;
+  const isShowNextButton = hasValidatedEmail || isValidCheck;
 
   const handleCheckValidEmail = async () => {
     const query = await refetch();
     setIsValidToastOpen(true);
 
     if (query.isSuccess) {
-      setIsShowNextButton(true);
+      setHasValidatedEmail(true);
       open(() => (
         <FormProvider {...methods}>
           <ServiceAgreeBottomSheet

--- a/src/app/join/mobile/components/JoinHeader/JoinHeader.tsx
+++ b/src/app/join/mobile/components/JoinHeader/JoinHeader.tsx
@@ -31,7 +31,7 @@ const JoinHeader = ({ role }: { role?: Role }) => {
   return (
     <>
       <header className={headerWrapper}>
-        <Icon icon="Arrow" width={20} height={20} color={colors.text06} onClick={goToPrev} />
+        <Icon icon="Arrow" width={24} height={24} color={colors.text06} onClick={goToPrev} />
         <h1 className={headerTitle}>{headerTitleMap[role]}</h1>
       </header>
 

--- a/src/app/join/mobile/components/ServiceAgreeBottomSheet/ServiceAgreeBottomSheet.tsx
+++ b/src/app/join/mobile/components/ServiceAgreeBottomSheet/ServiceAgreeBottomSheet.tsx
@@ -3,7 +3,6 @@ import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import AgreeAccordion from '../../../components/JoinCheckboxContainer/AgreeAccordion/AgreeAccordion';
 import JoinCheckbox from '../../../components/JoinCheckboxContainer/JoinCheckbox/JoinCheckbox';
 import Policy from '../../../components/JoinCheckboxContainer/Policy';
-import useServiceAgreeCheck from '../../../hooks/useServiceAgreeCheck';
 import {
   ADVERTISE_TEXT,
   PRIVACY_TEXT,
@@ -17,19 +16,20 @@ import {
 } from '../../page.css';
 
 import Button from '@/components/Button/Button';
+import { ParticipantJoinSchemaType } from '@/schema/join/ParticipantJoinSchema';
 
 interface ServiceAgreeBottomSheetProps {
   onConfirm: () => void;
 }
 
 const ServiceAgreeBottomSheet = ({ onConfirm }: ServiceAgreeBottomSheetProps) => {
-  const { control, setValue } = useFormContext();
+  const { control, setValue } = useFormContext<ParticipantJoinSchemaType>();
+
   const matchConsent = useWatch({ name: 'matchConsent', control });
+  const isTermOfService = useWatch({ name: 'isTermOfService', control });
+  const isPrivacy = useWatch({ name: 'isPrivacy', control });
 
-  const { serviceAgreeCheck, handleChangeCheck } = useServiceAgreeCheck();
-
-  const { isTermOfService, isPrivacy } = serviceAgreeCheck;
-  const isValid = serviceAgreeCheck.isTermOfService && serviceAgreeCheck.isPrivacy;
+  const isValid = isTermOfService && isPrivacy;
 
   return (
     <section className={serviceAgreeBottomSheetLayout}>
@@ -41,9 +41,7 @@ const ServiceAgreeBottomSheet = ({ onConfirm }: ServiceAgreeBottomSheetProps) =>
               label="서비스 이용약관 동의"
               className={checkboxWrapper}
               isChecked={isTermOfService}
-              onChange={(e) => {
-                handleChangeCheck(e, 'isTermOfService');
-              }}
+              onChange={() => setValue('isTermOfService', !isTermOfService)}
               isRequired
             />
           }
@@ -57,7 +55,7 @@ const ServiceAgreeBottomSheet = ({ onConfirm }: ServiceAgreeBottomSheetProps) =>
               label="개인정보 수집 및 이용 동의"
               className={checkboxWrapper}
               isChecked={isPrivacy}
-              onChange={(e) => handleChangeCheck(e, 'isPrivacy')}
+              onChange={() => setValue('isPrivacy', !isPrivacy)}
               isRequired
             />
           }

--- a/src/app/join/mobile/page.css.ts
+++ b/src/app/join/mobile/page.css.ts
@@ -9,10 +9,11 @@ export const layout = style({
 
 export const headerWrapper = style({
   display: 'grid',
-  gridTemplateColumns: '20px 1fr 20px',
+  gridTemplateColumns: '24px 1fr 24px',
   alignItems: 'center',
   justifyItems: 'center',
   padding: '1.2rem 1.6rem',
+  height: '5.4rem',
 });
 
 export const headerTitle = style({

--- a/src/components/Icon/icons/Arrow.tsx
+++ b/src/components/Icon/icons/Arrow.tsx
@@ -5,15 +5,15 @@ import { colors } from '@/styles/colors';
 const Arrow = (props: SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="20"
-      height="20"
-      viewBox="0 0 20 20"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path
-        d="M15.8334 10.0001H4.16669M4.16669 10.0001L10 15.8334M4.16669 10.0001L10 4.16675"
+        d="M19 12H5M5 12L12 19M5 12L12 5"
         stroke={props.color || colors.icon03}
         strokeWidth="2"
         strokeLinecap="round"

--- a/src/schema/join/ParticipantJoinSchema.ts
+++ b/src/schema/join/ParticipantJoinSchema.ts
@@ -1,88 +1,99 @@
 import { z } from 'zod';
 
 export type ParticipantJoinSchemaType = z.infer<ReturnType<typeof ParticipantJoinSchema>>;
+export type ParticipantJoinSubmitSchemaType = z.infer<
+  ReturnType<typeof ParticipantJoinSubmitSchema>
+>;
 
-const ParticipantJoinSchema = () => {
-  return z.object({
-    // 소셜 로그인 아이디: 필수. 유저 수정 불가.
-    oauthEmail: z
-      .string({ required_error: '소셜 로그인 정보가 없습니다' })
-      .email({ message: '이메일 형식이 올바르지 않아요' }),
+const requiredFields = {
+  // 소셜 로그인 아이디: 필수. 유저 수정 불가.
+  oauthEmail: z
+    .string({ required_error: '소셜 로그인 정보가 없습니다' })
+    .email({ message: '이메일 형식이 올바르지 않아요' }),
 
-    // 소셜 로그인 도메인
-    provider: z.union([
-      z.literal('GOOGLE', { message: '유효한 도메인이 아닙니다' }),
-      z.literal('NAVER'),
-    ]),
+  // 소셜 로그인 도메인
+  provider: z.union([
+    z.literal('GOOGLE', { message: '유효한 도메인이 아닙니다' }),
+    z.literal('NAVER'),
+  ]),
 
-    // 연락받을 이메일: 필수. 한글X. 이메일 형식.
-    contactEmail: z
-      .string({
-        required_error: '연락 받을 이메일을 입력해주세요',
-      })
-      .email({ message: '이메일 형식이 올바르지 않아요' }),
+  // 연락받을 이메일: 필수. 한글X. 이메일 형식.
+  contactEmail: z
+    .string({
+      required_error: '연락 받을 이메일을 입력해주세요',
+    })
+    .email({ message: '이메일 형식이 올바르지 않아요' }),
 
-    // 이름: 필수. 2자 이상 10자 이하. 한글, 영문만 입력.
-    name: z
-      .string({ required_error: '이름을 입력해주세요' })
-      .regex(/^[a-zA-Z가-힣]+$/, { message: '한글과 영문만 입력 가능합니다' })
-      .min(2, { message: '최소 2자 이상으로 입력해 주세요' })
-      .max(10, { message: '최대 10자 이하로 입력해 주세요' }),
+  // 이름: 필수. 2자 이상 10자 이하. 한글, 영문만 입력.
+  name: z
+    .string({ required_error: '이름을 입력해주세요' })
+    .regex(/^[a-zA-Z가-힣]+$/, { message: '한글과 영문만 입력 가능합니다' })
+    .min(2, { message: '최소 2자 이상으로 입력해 주세요' })
+    .max(10, { message: '최대 10자 이하로 입력해 주세요' }),
 
-    // 성별. 필수. 남자/여자/선택안함
-    gender: z.union([
-      z.literal('MALE', { message: '성별을 선택해주세요' }),
-      z.literal('FEMALE'),
-      z.literal('ALL'),
-    ]),
+  // 성별. 필수. 남자/여자/선택안함
+  gender: z.union([
+    z.literal('MALE', { message: '성별을 선택해주세요' }),
+    z.literal('FEMALE'),
+    z.literal('ALL'),
+  ]),
 
-    // 생년월일. 필수. yyyy.mm.dd
-    birthDate: z
-      .string({
-        required_error: '생년월일을 입력해주세요',
-      })
-      .regex(/^\d{4}\.\d{2}\.\d{2}$/, { message: 'YYYY.MM.DD 형식으로 입력해주세요' })
-      .refine(
-        (value) => {
-          const [year, month, day] = value.split('.').map(Number);
-          const date = new Date(year, month - 1, day);
-          return (
-            date.getFullYear() === year && date.getMonth() + 1 === month && date.getDate() === day
-          );
-        },
-        { message: '유효한 날짜를 입력해주세요' },
-      ),
-
-    // 거주 지역. 필수. 시.도(region), 시.군.구(area)
-    basicAddressInfo: z.object(
-      {
-        region: z.string({
-          required_error: '거주 지역의 시·도를 입력해주세요',
-        }),
-        area: z.string({
-          required_error: '거주 지역의 시·군·구를 입력해주세요',
-        }),
+  // 생년월일. 필수. yyyy.mm.dd
+  birthDate: z
+    .string({
+      required_error: '생년월일을 입력해주세요',
+    })
+    .regex(/^\d{4}\.\d{2}\.\d{2}$/, { message: 'YYYY.MM.DD 형식으로 입력해주세요' })
+    .refine(
+      (value) => {
+        const [year, month, day] = value.split('.').map(Number);
+        const date = new Date(year, month - 1, day);
+        return (
+          date.getFullYear() === year && date.getMonth() + 1 === month && date.getDate() === day
+        );
       },
-      { required_error: '거주 지역을 입력해주세요' },
+      { message: '유효한 날짜를 입력해주세요' },
     ),
 
-    // 추가 활동 지역. 선택. 시.도(region), 시.군.구(area)
-    additionalAddressInfo: z
-      .object({
-        region: z.string().optional(),
-        area: z.string().optional(),
-      })
-      .nullable(),
+  // 거주 지역. 필수. 시.도(region), 시.군.구(area)
+  basicAddressInfo: z.object(
+    {
+      region: z.string({
+        required_error: '거주 지역의 시·도를 입력해주세요',
+      }),
+      area: z.string({
+        required_error: '거주 지역의 시·군·구를 입력해주세요',
+      }),
+    },
+    { required_error: '거주 지역을 입력해주세요' },
+  ),
 
-    // 선호 실험 진행 방식. 선택. 대면/비대면/전체
-    matchType: z.union([z.literal('OFFLINE'), z.literal('ONLINE'), z.literal('ALL')]).optional(),
+  // 추가 활동 지역. 선택. 시.도(region), 시.군.구(area)
+  additionalAddressInfo: z
+    .object({
+      region: z.string().optional(),
+      area: z.string().optional(),
+    })
+    .nullable(),
 
-    // 이메일 수신 동의 여부.
-    adConsent: z.boolean(),
+  // 선호 실험 진행 방식. 선택. 대면/비대면/전체
+  matchType: z.union([z.literal('OFFLINE'), z.literal('ONLINE'), z.literal('ALL')]).optional(),
 
-    // 매칭 이메일 수신 동의 여부.
-    matchConsent: z.boolean(),
-  });
+  // 이메일 수신 동의 여부.
+  adConsent: z.boolean(),
+
+  // 매칭 이메일 수신 동의 여부.
+  matchConsent: z.boolean(),
 };
 
-export default ParticipantJoinSchema;
+export const ParticipantJoinSubmitSchema = () => {
+  return z.object(requiredFields);
+};
+
+export const ParticipantJoinSchema = () => {
+  return z.object({
+    ...requiredFields,
+    isTermOfService: z.boolean(), // 이용약관 동의 여부
+    isPrivacy: z.boolean(), // 개인정보 처리 동의 여부
+  });
+};


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->
closed #136 

## As-Is
<!-- 문제 상황 정의 -->
- ContactEmailStep에서 필수 동의 사항을 체크하지 않더라도 확인 버튼이 활성화되는 문제

## To-Be
<!-- 변경 사항 -->
- 필수 동의 사항을 zod Schema로 관리하고, submit할 데이터를 별도의 스키마로 관리
- 스텝을 뒤로 돌아가더라도 다음 버튼 활성화 유지
- 모바일 헤더 컴포넌트 높이, 아이콘 크기 디자인 수정사항 반영

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/58692f01-ceba-4d70-a867-1e97fc8f0ce0


## (Optional) Additional Description

### ParticipantJoinSubmitSchema

form data로 제출하지 않는 값을 react-hook-form으로 관리하는 것에 대해 어떻게 생각하시는지 궁금해요

기존에는 필수 체크 여부를 폼으로 제출하지 않아서 useServiceAgreeCheck 커스텀훅을 만들어 클라이언트 상태로 관리하였는데요. overlay.open() 으로 바텀시트를 열 경우 상태가 페이지와 바텀시트가 공유되지 않는 문제가 있어 폼데이터로 다루게 되었습니다. 그런데 찾아보니 다음 스텝으로 넘어가는 데에 영향을 준다면, react-hook-form으로 관리하는 것도 적절하다고 해서 의견이 궁금합니당
