### PR TITLE
[YS-449] design: 공고 상세 불필요한 height 제거 및 flex 추가

### DIFF
--- a/src/app/post/[post_id]/components/ExperimentPostInfo/ExperimentPostInfo.css.ts
+++ b/src/app/post/[post_id]/components/ExperimentPostInfo/ExperimentPostInfo.css.ts
@@ -6,7 +6,6 @@ import { fonts } from '@/styles/fonts.css';
 export const postInfoLayout = style({
   marginTop: '1.6rem',
   width: '100%',
-  height: '6rem',
 });
 
 globalStyle(`${postInfoLayout} h2`, {
@@ -56,4 +55,8 @@ export const buttonStyles = style({
   ...fonts.label.large.M14,
   color: colors.text03,
   cursor: 'pointer',
+});
+
+export const postTitle = style({
+  flex: 1,
 });

--- a/src/app/post/[post_id]/components/ExperimentPostInfo/ExperimentPostInfo.tsx
+++ b/src/app/post/[post_id]/components/ExperimentPostInfo/ExperimentPostInfo.tsx
@@ -11,6 +11,7 @@ import {
   postHeaderContainer,
   postInfoLayout,
   postSubInfo,
+  postTitle,
   viewsContainer,
 } from './ExperimentPostInfo.css';
 import { formatDate } from '../../ExperimentPostPage.utils';
@@ -73,7 +74,7 @@ const ExperimentPostInfo = ({ postDetailData }: ExperimentPostInfoProps) => {
     <>
       <div className={postInfoLayout}>
         <div className={postHeaderContainer}>
-          <h2>{postDetailData.title}</h2>
+          <h2 className={postTitle}>{postDetailData.title}</h2>
           {postDetailData.isAuthor && (
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.8rem' }}>
               <Link href={`/edit/${postDetailData.experimentPostId}`}>


### PR DESCRIPTION
## Issue Number

<!-- #이슈번호 -->
close #140 

## As-Is

공고 제목이 두 줄 이상 넘어가면 UI 깨짐

<!-- 문제 상황 정의 -->

## To-Be
공고 제목이 두 줄 이상 넘어가도 UI 깨지지 않도록 수정

<!-- 변경 사항 -->

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

as-is
<img width="990" alt="image" src="https://github.com/user-attachments/assets/4fbe7c72-e2e9-4a40-82fd-d62228a39125" />



to-be
<img width="1083" alt="image" src="https://github.com/user-attachments/assets/da4e0142-4a71-4c08-9fe4-134b701c3c94" />

## (Optional) Additional Description

불필요하게 들어간 `heigh`를 제거하고 공고 제목이 "수정 / 삭제" 버튼 영역에 영향을 주지 않도록 `flex: 1;`을 추가하였습니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 게시글 정보 레이아웃의 높이 제한이 제거되어, 콘텐츠에 따라 유연하게 높이가 조정됩니다.
  - 게시글 제목 영역이 가용 공간을 더 효과적으로 차지하도록 스타일이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->