### PR TITLE
[YS-458] 회원가입 완료 전에 페이지 전환 시 무한로딩 걸리는 문제 해결

### DIFF
--- a/src/apis/config/createBaseFetchClient.ts
+++ b/src/apis/config/createBaseFetchClient.ts
@@ -26,7 +26,7 @@ interface BaseFetchClientOptions {
   retryLogin?: <T>({ config, code, status, url }: RetryLoginParams) => Promise<T>;
 }
 
-export const createBaseFetchClient = (options: BaseFetchClientOptions) => {
+export const createBaseFetchClient = (options: BaseFetchClientOptions = {}) => {
   return {
     onRequestCallback: (config: RequestProps) => config,
 

--- a/src/apis/config/fetchClient.ts
+++ b/src/apis/config/fetchClient.ts
@@ -61,3 +61,9 @@ export const createSSRFetchClient = (accessToken?: string) => {
     },
   });
 };
+
+/**
+ * retryLogin 없는 fetchClient
+ * @description 토큰 재발급 시 무한 루프 방지를 위해 retryLogin 없는 fetchClient 생성
+ */
+export const refreshClient = createBaseFetchClient();

--- a/src/apis/config/fetchClient.ts
+++ b/src/apis/config/fetchClient.ts
@@ -66,4 +66,4 @@ export const createSSRFetchClient = (accessToken?: string) => {
  * retryLogin 없는 fetchClient
  * @description 토큰 재발급 시 무한 루프 방지를 위해 retryLogin 없는 fetchClient 생성
  */
-export const refreshClient = createBaseFetchClient();
+export const noRetryFetchClient = createBaseFetchClient();

--- a/src/apis/config/utils.ts
+++ b/src/apis/config/utils.ts
@@ -24,13 +24,22 @@ export const getSessionRefreshToken = async () => {
   try {
     if (isServer) {
       const session = await getServerSession(authOptions);
-      return session?.refreshToken || null;
+      return {
+        refreshToken: session?.refreshToken || null,
+        isTempUser: session?.isTempUser || null,
+      };
     } else {
       const session = await getSession();
-      return session?.refreshToken || null;
+      return {
+        refreshToken: session?.refreshToken || null,
+        isTempUser: session?.isTempUser || null,
+      };
     }
   } catch (_) {
-    return null;
+    return {
+      refreshToken: null,
+      isTempUser: null,
+    };
   }
 };
 
@@ -55,9 +64,9 @@ export const retryLogin = async <T>({
       });
     }
 
-    const refreshToken = await getSessionRefreshToken();
+    const { refreshToken, isTempUser } = await getSessionRefreshToken();
 
-    if (!refreshToken) {
+    if (!refreshToken || isTempUser) {
       throw new CustomError({
         status,
         code,

--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -1,4 +1,4 @@
-import { fetchClient } from './config/fetchClient';
+import { fetchClient, refreshClient } from './config/fetchClient';
 import { ValidateContactEmailParams } from './user';
 
 import { API_URL } from '@/constants/url';
@@ -97,7 +97,7 @@ export const joinParticipant = async (params: ParticipantJoinSchemaType) => {
 };
 
 export const updateAccessToken = async (refreshToken: string) => {
-  return await fetchClient.post<LoginResponse>(API_URL.refresh, { body: { refreshToken } });
+  return await refreshClient.post<LoginResponse>(API_URL.refresh, { body: { refreshToken } });
 };
 
 export const validateContactEmailInfo = async ({ contactEmail }: ValidateContactEmailParams) => {

--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -1,4 +1,4 @@
-import { fetchClient, refreshClient } from './config/fetchClient';
+import { fetchClient, noRetryFetchClient } from './config/fetchClient';
 import { ValidateContactEmailParams } from './user';
 
 import { API_URL } from '@/constants/url';
@@ -97,7 +97,7 @@ export const joinParticipant = async (params: ParticipantJoinSchemaType) => {
 };
 
 export const updateAccessToken = async (refreshToken: string) => {
-  return await refreshClient.post<LoginResponse>(API_URL.refresh, { body: { refreshToken } });
+  return await noRetryFetchClient.post<LoginResponse>(API_URL.refresh, { body: { refreshToken } });
 };
 
 export const validateContactEmailInfo = async ({ contactEmail }: ValidateContactEmailParams) => {


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->
close #150 

## As-Is
<!-- 문제 상황 정의 -->
- refresh token이 유효하지 않은 경우 무한 루프 발생

## To-Be
<!-- 변경 사항 -->
- temp user인지를 체크하고 에러 발생
- temp user만 처리하면, 로그인 성공한 user도 refresh token이 만료될 경우 동일하게 무한 루프가 걸릴 것임.
  - 근본적인 이유 발견: updateRefreshToken을 호출할 때 fetchClient를 사용하는데, 그 내부에서 retryLogin이 또 실행되면서 무한루프가 걸리는 것이다.
  - 이를 토큰 갱신할 때만 retryLogin 콜백을 주입하지 않은 noRetryFetchClient 를 사용한다.

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description
