### PR TITLE
[YS-460] 로그인 API에 redirect uri를 보내 개발 서버에서도 구글 OAuth 로그인 적용

### DIFF
--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -66,9 +66,15 @@ export interface NaverLoginParams {
   state: string;
 }
 
-export const googleLogin = async (code: string, role: string) => {
+export interface GoogleLoginParams {
+  code: string;
+  role: string;
+  redirectUri: string;
+}
+
+export const googleLogin = async ({ code, role, redirectUri }: GoogleLoginParams) => {
   return await fetchClient.post<LoginResponse>(API_URL.google(role), {
-    body: { authorizationCode: code },
+    body: { authorizationCode: code, redirectUri },
   });
 };
 

--- a/src/app/login/hooks/useGoogleLoginMutation.ts
+++ b/src/app/login/hooks/useGoogleLoginMutation.ts
@@ -4,14 +4,13 @@ import { getAuthErrorMessage } from '../LoginPage.utils';
 
 import { CustomError } from '@/apis/config/error';
 import { fetchClient } from '@/apis/config/fetchClient';
-import { googleLogin, LoginResponse } from '@/apis/login';
+import { googleLogin, GoogleLoginParams, LoginResponse } from '@/apis/login';
 import { loginWithCredentials } from '@/lib/auth-utils';
 import { identifyUser, setUserProperties } from '@/lib/mixpanelClient';
 
-interface GoogleLoginParams {
-  code: string;
-  role: string;
-}
+const redirectUri = process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI || '';
+
+interface LoginParams extends Omit<GoogleLoginParams, 'redirectUri'> {}
 
 interface UseGoogleLoginMutationProps {
   onSuccessLogin: () => void;
@@ -26,8 +25,8 @@ const useGoogleLoginMutation = ({
 }: UseGoogleLoginMutationProps) => {
   const queryClient = useQueryClient();
 
-  return useMutation<LoginResponse, CustomError, GoogleLoginParams>({
-    mutationFn: ({ code, role }: GoogleLoginParams) => googleLogin(code, role),
+  return useMutation<LoginResponse, CustomError, LoginParams>({
+    mutationFn: ({ code, role }: LoginParams) => googleLogin({ code, role, redirectUri }),
     onSuccess: async ({ isRegistered, accessToken, refreshToken, memberInfo }) => {
       if (isRegistered) {
         fetchClient.onRequest((config) => {

--- a/src/app/login/hooks/useGoogleLoginMutation.ts
+++ b/src/app/login/hooks/useGoogleLoginMutation.ts
@@ -10,7 +10,7 @@ import { identifyUser, setUserProperties } from '@/lib/mixpanelClient';
 
 const redirectUri = process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI || '';
 
-interface LoginParams extends Omit<GoogleLoginParams, 'redirectUri'> {}
+type LoginParams = Omit<GoogleLoginParams, 'redirectUri'>;
 
 interface UseGoogleLoginMutationProps {
   onSuccessLogin: () => void;


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->
close #155 

## As-Is
<!-- 문제 상황 정의 -->
- 개발 서버  or 로컬 서버 한 곳에서만 oauth 로그인을 못함

## To-Be
<!-- 변경 사항 -->
- redirect uri를 body로 보내 서버 1대로 두 도메인에서 구글 oauth 로그인이 가능하도록 처리

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description
