### PR TITLE
Revert [YS-460] 로그인 API에 redirect uri를 보내 개발 서버에서도 구글 OAuth 로그인 적용

### DIFF
--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -66,15 +66,9 @@ export interface NaverLoginParams {
   state: string;
 }
 
-export interface GoogleLoginParams {
-  code: string;
-  role: string;
-  redirectUri: string;
-}
-
-export const googleLogin = async ({ code, role, redirectUri }: GoogleLoginParams) => {
+export const googleLogin = async (code: string, role: string) => {
   return await fetchClient.post<LoginResponse>(API_URL.google(role), {
-    body: { authorizationCode: code, redirectUri },
+    body: { authorizationCode: code },
   });
 };
 

--- a/src/app/login/hooks/useGoogleLoginMutation.ts
+++ b/src/app/login/hooks/useGoogleLoginMutation.ts
@@ -4,13 +4,14 @@ import { getAuthErrorMessage } from '../LoginPage.utils';
 
 import { CustomError } from '@/apis/config/error';
 import { fetchClient } from '@/apis/config/fetchClient';
-import { googleLogin, GoogleLoginParams, LoginResponse } from '@/apis/login';
+import { googleLogin, LoginResponse } from '@/apis/login';
 import { loginWithCredentials } from '@/lib/auth-utils';
 import { identifyUser, setUserProperties } from '@/lib/mixpanelClient';
 
-const redirectUri = process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI || '';
-
-type LoginParams = Omit<GoogleLoginParams, 'redirectUri'>;
+interface GoogleLoginParams {
+  code: string;
+  role: string;
+}
 
 interface UseGoogleLoginMutationProps {
   onSuccessLogin: () => void;
@@ -25,8 +26,8 @@ const useGoogleLoginMutation = ({
 }: UseGoogleLoginMutationProps) => {
   const queryClient = useQueryClient();
 
-  return useMutation<LoginResponse, CustomError, LoginParams>({
-    mutationFn: ({ code, role }: LoginParams) => googleLogin({ code, role, redirectUri }),
+  return useMutation<LoginResponse, CustomError, GoogleLoginParams>({
+    mutationFn: ({ code, role }: GoogleLoginParams) => googleLogin(code, role),
     onSuccess: async ({ isRegistered, accessToken, refreshToken, memberInfo }) => {
       if (isRegistered) {
         fetchClient.onRequest((config) => {


### PR DESCRIPTION
구글 로그인 API 요청에 redirectUri를 보내는 PR revert

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 구글 로그인 시 불필요한 리디렉션 정보가 더 이상 전송되지 않도록 개선되었습니다.
  - 구글 로그인 관련 입력값이 간소화되어, 로그인 과정이 더욱 원활해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->