### PR TITLE
[YS-461] 연구자 회원가입 불필요한 리렌더링 개선 및 ResearcherJoinSchema 개선

### DIFF
--- a/src/apis/config/createBaseFetchClient.ts
+++ b/src/apis/config/createBaseFetchClient.ts
@@ -59,7 +59,7 @@ export const createBaseFetchClient = (options: BaseFetchClientOptions = {}) => {
             });
           }
 
-          throw new CustomError({ ...apiError, status: response.status });
+          throw new CustomError({ code: apiError.code, status: response.status });
         }
 
         return await response.json();

--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -3,7 +3,7 @@ import { ValidateContactEmailParams } from './user';
 
 import { API_URL } from '@/constants/url';
 import { ParticipantJoinSubmitSchemaType } from '@/schema/join/ParticipantJoinSchema';
-import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
+import { ResearcherJoinSubmitSchemaType } from '@/schema/join/ResearcherJoinSchema';
 import { Role } from '@/types/user';
 
 export interface UnivAuthCodeResponse {
@@ -88,7 +88,7 @@ export const verifyUnivAuthCode = async (univEmail: string, inputCode: string) =
   });
 };
 
-export const joinResearcher = async (params: ResearcherJoinSchemaType) => {
+export const joinResearcher = async (params: ResearcherJoinSubmitSchemaType) => {
   return await fetchClient.post<JoinResponse>(API_URL.joinResearcher, { body: params });
 };
 

--- a/src/app/join/JoinPage.css.ts
+++ b/src/app/join/JoinPage.css.ts
@@ -49,7 +49,7 @@ export const joinContentContainer = style({
   width: '100%',
   display: 'flex',
   flexDirection: 'column',
-  gap: '2.8rem',
+  gap: '0.8rem',
   borderRadius: '1.2rem',
   padding: '3.2rem 4rem',
 });

--- a/src/app/join/JoinPage.css.ts
+++ b/src/app/join/JoinPage.css.ts
@@ -82,3 +82,19 @@ export const joinForm = style({
   alignItems: 'center',
   gap: '4rem',
 });
+
+export const nextButton = style({
+  ...fonts.body.normal.SB16,
+  backgroundColor: colors.primaryMint,
+  color: colors.text01,
+  borderRadius: '1.2rem',
+  padding: '1.2rem 0',
+  width: '20rem',
+  alignItems: 'center',
+  selectors: {
+    '&:disabled': {
+      color: colors.text02,
+      backgroundColor: colors.field04,
+    },
+  },
+});

--- a/src/app/join/JoinPage.css.ts
+++ b/src/app/join/JoinPage.css.ts
@@ -82,19 +82,3 @@ export const joinForm = style({
   alignItems: 'center',
   gap: '4rem',
 });
-
-export const nextButton = style({
-  ...fonts.body.normal.SB16,
-  backgroundColor: colors.primaryMint,
-  color: colors.text01,
-  borderRadius: '1.2rem',
-  padding: '1.2rem 0',
-  width: '20rem',
-  alignItems: 'center',
-  selectors: {
-    '&:disabled': {
-      color: colors.text02,
-      backgroundColor: colors.field04,
-    },
-  },
-});

--- a/src/app/join/components/JoinCheckboxContainer/JoinCheckboxContainer.tsx
+++ b/src/app/join/components/JoinCheckboxContainer/JoinCheckboxContainer.tsx
@@ -1,6 +1,5 @@
-import { Controller, useFormContext, useWatch } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 
-import { ServiceAgreeCheck } from '../../JoinPage.types';
 import AgreeAccordion from './AgreeAccordion/AgreeAccordion';
 import JoinCheckbox from './JoinCheckbox/JoinCheckbox';
 import { termContainer } from './JoinCheckboxContainer.css';
@@ -12,24 +11,22 @@ import {
   SERVICE_TERM_TEXT,
 } from '../../JoinPage.constants';
 
-interface JoinCheckboxContainerProps {
-  serviceAgreeCheck: ServiceAgreeCheck;
-  handleAllCheck: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleChange: (e: React.ChangeEvent<HTMLInputElement>, name: string) => void;
-}
-
-const JoinCheckboxContainer = ({
-  serviceAgreeCheck,
-  handleAllCheck,
-  handleChange,
-}: JoinCheckboxContainerProps) => {
+const JoinCheckboxContainer = () => {
   const { control, setValue } = useFormContext();
+
   const adConsent = useWatch({ name: 'adConsent', control });
   const matchConsent = useWatch({ name: 'matchConsent', control });
-
-  const { isTermOfService, isPrivacy } = serviceAgreeCheck;
+  const isTermOfService = useWatch({ name: 'isTermOfService', control });
+  const isPrivacy = useWatch({ name: 'isPrivacy', control });
 
   const isAllCheck = isTermOfService && isPrivacy && adConsent && (matchConsent ?? true);
+
+  const handleAllCheck = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue('isTermOfService', e.target.checked);
+    setValue('isPrivacy', e.target.checked);
+    setValue('adConsent', e.target.checked);
+    matchConsent && setValue('matchConsent', e.target.checked);
+  };
 
   return (
     <div className={termContainer}>
@@ -47,7 +44,7 @@ const JoinCheckboxContainer = ({
           <JoinCheckbox
             label="서비스 이용약관 동의"
             isChecked={isTermOfService}
-            onChange={(e) => handleChange(e, 'isTermOfService')}
+            onChange={(e) => setValue('isTermOfService', e.target.checked)}
             isRequired
           />
         }
@@ -60,7 +57,7 @@ const JoinCheckboxContainer = ({
           <JoinCheckbox
             label="개인정보 수집 및 이용 동의"
             isChecked={isPrivacy}
-            onChange={(e) => handleChange(e, 'isPrivacy')}
+            onChange={(e) => setValue('isPrivacy', e.target.checked)}
             isRequired
           />
         }
@@ -70,18 +67,10 @@ const JoinCheckboxContainer = ({
       {/* 이메일/SMS 수신 동의 */}
       <AgreeAccordion
         trigger={
-          <Controller
-            name="adConsent"
-            control={control}
-            render={({ field }) => {
-              return (
-                <JoinCheckbox
-                  label="[선택] 광고성 정보 이메일/SMS 수신 동의"
-                  isChecked={field.value}
-                  onChange={() => setValue('adConsent', !field.value)}
-                />
-              );
-            }}
+          <JoinCheckbox
+            label="[선택] 광고성 정보 이메일/SMS 수신 동의"
+            isChecked={adConsent}
+            onChange={(e) => setValue('adConsent', e.target.checked)}
           />
         }
         content={<Policy content={ADVERTISE_TEXT} />}
@@ -91,18 +80,10 @@ const JoinCheckboxContainer = ({
       {matchConsent !== undefined && (
         <AgreeAccordion
           trigger={
-            <Controller
-              name="matchConsent"
-              control={control}
-              render={({ field }) => {
-                return (
-                  <JoinCheckbox
-                    label="[선택] 개인정보 수집 및 이용 동의-실험 추천·혜택"
-                    isChecked={field.value}
-                    onChange={() => setValue('matchConsent', !field.value)}
-                  />
-                );
-              }}
+            <JoinCheckbox
+              label="[선택] 개인정보 수집 및 이용 동의-실험 추천·혜택"
+              isChecked={matchConsent}
+              onChange={(e) => setValue('matchConsent', e.target.checked)}
             />
           }
           content={<Policy content={RECOMMEND_ALERT_TEXT} />}

--- a/src/app/join/components/JoinCheckboxContainer/JoinCheckboxContainer.tsx
+++ b/src/app/join/components/JoinCheckboxContainer/JoinCheckboxContainer.tsx
@@ -22,10 +22,13 @@ const JoinCheckboxContainer = () => {
   const isAllCheck = isTermOfService && isPrivacy && adConsent && (matchConsent ?? true);
 
   const handleAllCheck = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (matchConsent) {
+      setValue('matchConsent', e.target.checked);
+    }
+
     setValue('isTermOfService', e.target.checked);
     setValue('isPrivacy', e.target.checked);
     setValue('adConsent', e.target.checked);
-    matchConsent && setValue('matchConsent', e.target.checked);
   };
 
   return (

--- a/src/app/join/components/JoinInput/JoinInput.css.ts
+++ b/src/app/join/components/JoinInput/JoinInput.css.ts
@@ -60,6 +60,7 @@ export const infoContainer = style({
   justifyContent: 'space-between',
   alignItems: 'center',
   width: '100%',
+  height: '2rem',
 });
 
 export const errorMessage = style({

--- a/src/app/join/desktop/Participant/JoinEmailStep/JoinEmailStep.tsx
+++ b/src/app/join/desktop/Participant/JoinEmailStep/JoinEmailStep.tsx
@@ -8,7 +8,6 @@ import JoinCheckboxContainer from '../../../components/JoinCheckboxContainer/Joi
 import JoinInput from '../../../components/JoinInput/JoinInput';
 
 import useCheckValidEmailInfoQuery from '@/app/join/hooks/useCheckValidEmailInfoQuery';
-import useServiceAgreeCheck from '@/app/join/hooks/useServiceAgreeCheck';
 import { joinContentContainer, joinForm, nextButton } from '@/app/join/JoinPage.css';
 import ButtonInput from '@/components/ButtonInput/ButtonInput';
 import { ParticipantJoinSchemaType } from '@/schema/join/ParticipantJoinSchema';
@@ -21,17 +20,13 @@ const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
   const {
     control,
     trigger,
-    setValue,
     formState: { errors },
   } = useFormContext<ParticipantJoinSchemaType>();
 
-  const { serviceAgreeCheck, handleAllCheck, handleChangeCheck } = useServiceAgreeCheck({
-    onCheckAdConsent: (checked) => setValue('adConsent', checked),
-    onCheckMatchConsent: (checked) => setValue('matchConsent', checked),
-  });
-
   const oauthEmail = useWatch({ name: 'oauthEmail', control });
   const contactEmail = useWatch({ name: 'contactEmail', control });
+  const isTermOfService = useWatch({ name: 'isTermOfService', control });
+  const isPrivacy = useWatch({ name: 'isPrivacy', control });
 
   const {
     refetch,
@@ -48,11 +43,7 @@ const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
   };
 
   const allValid =
-    isValidEmail &&
-    contactEmail &&
-    !errors.contactEmail &&
-    serviceAgreeCheck.isTermOfService &&
-    serviceAgreeCheck.isPrivacy;
+    isValidEmail && contactEmail && !errors.contactEmail && isTermOfService && isPrivacy;
 
   const handleNextStep = async () => {
     const isValid = await trigger(['oauthEmail', 'contactEmail']);
@@ -95,11 +86,7 @@ const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
         />
 
         {/* 동의 체크 항목 */}
-        <JoinCheckboxContainer
-          serviceAgreeCheck={serviceAgreeCheck}
-          handleAllCheck={handleAllCheck}
-          handleChange={handleChangeCheck}
-        />
+        <JoinCheckboxContainer />
       </div>
       <button className={nextButton} onClick={handleNextStep} disabled={!allValid}>
         다음

--- a/src/app/join/desktop/Researcher/JoinButton/JoinButton.tsx
+++ b/src/app/join/desktop/Researcher/JoinButton/JoinButton.tsx
@@ -1,0 +1,33 @@
+import Button from '@/components/Button/Button';
+import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
+import { useFormContext, useWatch } from 'react-hook-form';
+
+interface JoinButtonProps {
+  onSubmit: () => void;
+}
+
+const JoinButton = ({ onSubmit }: JoinButtonProps) => {
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<ResearcherJoinSchemaType>();
+  const values = useWatch({ name: ['name', 'univName', 'major'], control });
+  const isAllFilled = values.every((value) => (value ?? '').trim() !== '' && value !== undefined);
+
+  const isValidForm = !(isAllFilled && Object.keys(errors).length === 0);
+
+  return (
+    <Button
+      type="submit"
+      variant="primary"
+      size="medium"
+      onClick={onSubmit}
+      disabled={!isValidForm}
+      width="20rem"
+    >
+      회원가입
+    </Button>
+  );
+};
+
+export default JoinButton;

--- a/src/app/join/desktop/Researcher/JoinButton/JoinButton.tsx
+++ b/src/app/join/desktop/Researcher/JoinButton/JoinButton.tsx
@@ -15,7 +15,7 @@ const JoinButton = ({ onSubmit }: JoinButtonProps) => {
   const values = useWatch({ name: ['name', 'univName', 'major'], control });
   const isAllFilled = values.every((value) => (value ?? '').trim() !== '' && value !== undefined);
 
-  const isValidForm = !(isAllFilled && Object.keys(errors).length === 0);
+  const isValidForm = isAllFilled && Object.keys(errors).length === 0;
 
   return (
     <Button

--- a/src/app/join/desktop/Researcher/JoinButton/JoinButton.tsx
+++ b/src/app/join/desktop/Researcher/JoinButton/JoinButton.tsx
@@ -1,6 +1,7 @@
+import { useFormContext, useWatch } from 'react-hook-form';
+
 import Button from '@/components/Button/Button';
 import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
-import { useFormContext, useWatch } from 'react-hook-form';
 
 interface JoinButtonProps {
   onSubmit: () => void;

--- a/src/app/join/desktop/Researcher/JoinEmailStep/JoinEmailStep.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/JoinEmailStep.tsx
@@ -10,7 +10,6 @@ import JoinCheckboxContainer from '../../../components/JoinCheckboxContainer/Joi
 import JoinInput from '../../../components/JoinInput/JoinInput';
 
 import useCheckValidEmailInfoMutation from '@/app/join/hooks/useCheckValidEmailInfoMutation';
-import useVerifyUnivEmail from '@/app/join/hooks/useVerifyUnivEmail';
 import { joinContentContainer, joinForm } from '@/app/join/JoinPage.css';
 import ButtonInput from '@/components/ButtonInput/ButtonInput';
 import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
@@ -21,7 +20,6 @@ interface JoinEmailStepProps {
 
 const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
   const { control, getValues } = useFormContext<ResearcherJoinSchemaType>();
-  const { isEmailVerified, handleVerifyEmail, handleResetVerifyEmail } = useVerifyUnivEmail();
 
   const {
     mutate: checkValidEmail,
@@ -73,16 +71,12 @@ const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
         />
 
         {/* 학교 메일 인증 */}
-        <UnivAuthInput
-          isEmailVerified={isEmailVerified}
-          handleVerifyEmail={handleVerifyEmail}
-          handleResetVerifyEmail={handleResetVerifyEmail}
-        />
+        <UnivAuthInput />
 
         {/* 동의 체크 항목 */}
         <JoinCheckboxContainer />
       </div>
-      <NextButton onNext={onNext} isEmailVerified={isEmailVerified} />
+      <NextButton onNext={onNext} />
     </section>
   );
 };

--- a/src/app/join/desktop/Researcher/JoinEmailStep/JoinEmailStep.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/JoinEmailStep.tsx
@@ -21,11 +21,8 @@ interface JoinEmailStepProps {
 }
 
 const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
-  const { control, setValue, getValues } = useFormContext<ResearcherJoinSchemaType>();
+  const { control, getValues } = useFormContext<ResearcherJoinSchemaType>();
   const { isEmailVerified, handleVerifyEmail, handleResetVerifyEmail } = useVerifyUnivEmail();
-  const { serviceAgreeCheck, handleAllCheck, handleChangeCheck } = useServiceAgreeCheck({
-    onCheckAdConsent: (checked) => setValue('adConsent', checked),
-  });
 
   const {
     mutate: checkValidEmail,
@@ -34,8 +31,6 @@ const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
   } = useCheckValidEmailInfoMutation();
 
   const [isValidToastOpen, setIsValidToastOpen] = useState(false);
-
-  const isRequiredChecked = serviceAgreeCheck.isTermOfService && serviceAgreeCheck.isPrivacy;
 
   const handleCheckValidEmail = async () => {
     checkValidEmail(getValues('contactEmail'), {
@@ -86,17 +81,9 @@ const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
         />
 
         {/* 동의 체크 항목 */}
-        <JoinCheckboxContainer
-          serviceAgreeCheck={serviceAgreeCheck}
-          handleAllCheck={handleAllCheck}
-          handleChange={handleChangeCheck}
-        />
+        <JoinCheckboxContainer />
       </div>
-      <NextButton
-        onNext={onNext}
-        isRequiredChecked={isRequiredChecked}
-        isEmailVerified={isEmailVerified}
-      />
+      <NextButton onNext={onNext} isEmailVerified={isEmailVerified} />
     </section>
   );
 };

--- a/src/app/join/desktop/Researcher/JoinEmailStep/JoinEmailStep.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/JoinEmailStep.tsx
@@ -10,7 +10,6 @@ import JoinCheckboxContainer from '../../../components/JoinCheckboxContainer/Joi
 import JoinInput from '../../../components/JoinInput/JoinInput';
 
 import useCheckValidEmailInfoMutation from '@/app/join/hooks/useCheckValidEmailInfoMutation';
-import useServiceAgreeCheck from '@/app/join/hooks/useServiceAgreeCheck';
 import useVerifyUnivEmail from '@/app/join/hooks/useVerifyUnivEmail';
 import { joinContentContainer, joinForm } from '@/app/join/JoinPage.css';
 import ButtonInput from '@/components/ButtonInput/ButtonInput';

--- a/src/app/join/desktop/Researcher/JoinEmailStep/JoinEmailStep.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/JoinEmailStep.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import NextButton from './NextButton';
@@ -28,9 +28,13 @@ const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
   } = useCheckValidEmailInfoMutation();
 
   const [isValidToastOpen, setIsValidToastOpen] = useState(false);
+  const verifiedEmail = useRef('');
 
   const handleCheckValidEmail = async () => {
     checkValidEmail(getValues('contactEmail'), {
+      onSuccess: () => {
+        verifiedEmail.current = getValues('contactEmail');
+      },
       onSettled: () => {
         setIsValidToastOpen(true);
       },
@@ -76,7 +80,7 @@ const JoinEmailStep = ({ onNext }: JoinEmailStepProps) => {
         {/* 동의 체크 항목 */}
         <JoinCheckboxContainer />
       </div>
-      <NextButton onNext={onNext} />
+      <NextButton onNext={onNext} verifiedEmail={verifiedEmail.current} />
     </section>
   );
 };

--- a/src/app/join/desktop/Researcher/JoinEmailStep/NextButton.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/NextButton.tsx
@@ -1,23 +1,25 @@
-import { useFormContext, useFormState } from 'react-hook-form';
+import { useFormContext, useFormState, useWatch } from 'react-hook-form';
 
 import Button from '@/components/Button/Button';
 import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
 
 interface NextButtonProps {
   onNext: () => void;
-  isRequiredChecked: boolean;
   isEmailVerified: boolean;
 }
 
-const NextButton = ({ onNext, isRequiredChecked, isEmailVerified }: NextButtonProps) => {
+const NextButton = ({ onNext, isEmailVerified }: NextButtonProps) => {
   const { trigger, control } = useFormContext<ResearcherJoinSchemaType>();
   const { errors } = useFormState({
     control,
     name: ['contactEmail', 'univEmail'],
   });
 
+  const isTermOfService = useWatch({ name: 'isTermOfService', control });
+  const isPrivacy = useWatch({ name: 'isPrivacy', control });
+
   const isValidForm =
-    !errors.contactEmail && !errors.univEmail && isEmailVerified && isRequiredChecked;
+    !errors.contactEmail && !errors.univEmail && isEmailVerified && isTermOfService && isPrivacy;
 
   const handleNextStep = async () => {
     const isValid = await trigger(['oauthEmail', 'contactEmail', 'univEmail']);

--- a/src/app/join/desktop/Researcher/JoinEmailStep/NextButton.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/NextButton.tsx
@@ -5,21 +5,29 @@ import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
 
 interface NextButtonProps {
   onNext: () => void;
+  verifiedEmail: string;
 }
 
-const NextButton = ({ onNext }: NextButtonProps) => {
+const NextButton = ({ onNext, verifiedEmail }: NextButtonProps) => {
   const { trigger, control } = useFormContext<ResearcherJoinSchemaType>();
   const { errors } = useFormState({
     control,
     name: ['contactEmail', 'univEmail'],
   });
 
+  const contactEmail = useWatch({ name: 'contactEmail', control });
   const isTermOfService = useWatch({ name: 'isTermOfService', control });
   const isPrivacy = useWatch({ name: 'isPrivacy', control });
   const isEmailVerified = useWatch({ name: 'isEmailVerified', control });
 
   const isValidForm =
-    !errors.contactEmail && !errors.univEmail && isEmailVerified && isTermOfService && isPrivacy;
+    Boolean(verifiedEmail) &&
+    verifiedEmail === contactEmail &&
+    !errors.contactEmail &&
+    !errors.univEmail &&
+    isEmailVerified &&
+    isTermOfService &&
+    isPrivacy;
 
   const handleNextStep = async () => {
     const isValid = await trigger(['oauthEmail', 'contactEmail', 'univEmail']);

--- a/src/app/join/desktop/Researcher/JoinEmailStep/NextButton.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/NextButton.tsx
@@ -1,0 +1,42 @@
+import { useFormContext, useFormState } from 'react-hook-form';
+
+import Button from '@/components/Button/Button';
+import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
+
+interface NextButtonProps {
+  onNext: () => void;
+  isRequiredChecked: boolean;
+  isEmailVerified: boolean;
+}
+
+const NextButton = ({ onNext, isRequiredChecked, isEmailVerified }: NextButtonProps) => {
+  const { trigger, control } = useFormContext<ResearcherJoinSchemaType>();
+  const { errors } = useFormState({
+    control,
+    name: ['contactEmail', 'univEmail'],
+  });
+
+  const isValidForm =
+    !errors.contactEmail && !errors.univEmail && isEmailVerified && isRequiredChecked;
+
+  const handleNextStep = async () => {
+    const isValid = await trigger(['oauthEmail', 'contactEmail', 'univEmail']);
+    if (isValid) {
+      onNext();
+    }
+  };
+
+  return (
+    <Button
+      variant="primary"
+      size="medium"
+      onClick={handleNextStep}
+      disabled={!isValidForm}
+      width="20rem"
+    >
+      다음
+    </Button>
+  );
+};
+
+export default NextButton;

--- a/src/app/join/desktop/Researcher/JoinEmailStep/NextButton.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/NextButton.tsx
@@ -5,10 +5,9 @@ import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
 
 interface NextButtonProps {
   onNext: () => void;
-  isEmailVerified: boolean;
 }
 
-const NextButton = ({ onNext, isEmailVerified }: NextButtonProps) => {
+const NextButton = ({ onNext }: NextButtonProps) => {
   const { trigger, control } = useFormContext<ResearcherJoinSchemaType>();
   const { errors } = useFormState({
     control,
@@ -17,6 +16,7 @@ const NextButton = ({ onNext, isEmailVerified }: NextButtonProps) => {
 
   const isTermOfService = useWatch({ name: 'isTermOfService', control });
   const isPrivacy = useWatch({ name: 'isPrivacy', control });
+  const isEmailVerified = useWatch({ name: 'isEmailVerified', control });
 
   const isValidForm =
     !errors.contactEmail && !errors.univEmail && isEmailVerified && isTermOfService && isPrivacy;

--- a/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/AuthCodeInput/AuthCodeInput.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/AuthCodeInput/AuthCodeInput.tsx
@@ -23,16 +23,11 @@ const AUTH_CODE_VALID_LENGTH = 6;
 
 interface AuthCodeInputProps {
   authTimer: number;
-  handleVerifyEmail: () => void;
   handleSendUnivAuthCode: () => void;
 }
 
-const AuthCodeInput = ({
-  authTimer,
-  handleVerifyEmail,
-  handleSendUnivAuthCode,
-}: AuthCodeInputProps) => {
-  const { getValues } = useFormContext<ResearcherJoinSchemaType>();
+const AuthCodeInput = ({ authTimer, handleSendUnivAuthCode }: AuthCodeInputProps) => {
+  const { getValues, setValue } = useFormContext<ResearcherJoinSchemaType>();
   const { mutate: verifyEmail, isSuccess: isUnivVerify } = useVerifyUnivAuthCodeMutation();
   const [isToastOpen, setIsToastOpen] = useState(false);
   const [authCode, setAuthCode] = useState('');
@@ -52,7 +47,7 @@ const AuthCodeInput = ({
       {
         onSuccess: () => {
           setIsToastOpen(true);
-          handleVerifyEmail();
+          setValue('isEmailVerified', true);
           setError('');
         },
         onError: (error) => {

--- a/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/AuthCodeInput/AuthCodeInput.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/AuthCodeInput/AuthCodeInput.tsx
@@ -24,9 +24,10 @@ const AUTH_CODE_VALID_LENGTH = 6;
 interface AuthCodeInputProps {
   authTimer: number;
   handleSendUnivAuthCode: () => void;
+  stopTimer: () => void;
 }
 
-const AuthCodeInput = ({ authTimer, handleSendUnivAuthCode }: AuthCodeInputProps) => {
+const AuthCodeInput = ({ authTimer, handleSendUnivAuthCode, stopTimer }: AuthCodeInputProps) => {
   const { getValues, setValue } = useFormContext<ResearcherJoinSchemaType>();
   const { mutate: verifyEmail, isSuccess: isUnivVerify } = useVerifyUnivAuthCodeMutation();
   const [isToastOpen, setIsToastOpen] = useState(false);
@@ -49,6 +50,7 @@ const AuthCodeInput = ({ authTimer, handleSendUnivAuthCode }: AuthCodeInputProps
           setIsToastOpen(true);
           setValue('isEmailVerified', true);
           setError('');
+          stopTimer();
         },
         onError: (error) => {
           setError(error.message);

--- a/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.css.ts
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.css.ts
@@ -39,4 +39,5 @@ export const editButton = style({
 export const errorMessage = style({
   ...fonts.label.large.R14,
   color: colors.textAlert,
+  height: '2.2rem',
 });

--- a/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
@@ -29,7 +29,7 @@ const getButtonText = (isLoading: boolean, isAuthenticated: boolean) => {
 };
 
 const UnivAuthInput = () => {
-  const { control, setValue, setError } = useFormContext<ResearcherJoinSchemaType>();
+  const { control, setValue, clearErrors } = useFormContext<ResearcherJoinSchemaType>();
 
   const {
     data: authCodeData,
@@ -67,6 +67,7 @@ const UnivAuthInput = () => {
     setIsEmailSent(false);
     setValue('isEmailVerified', false);
     stopTimer();
+    clearErrors('univEmail');
   };
 
   return (

--- a/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
@@ -120,7 +120,11 @@ const UnivAuthInput = () => {
       />
 
       {isEmailSent && (
-        <AuthCodeInput authTimer={authTimer} handleSendUnivAuthCode={handleSendUnivAuthCode} />
+        <AuthCodeInput
+          authTimer={authTimer}
+          handleSendUnivAuthCode={handleSendUnivAuthCode}
+          stopTimer={stopTimer}
+        />
       )}
       <EmailToast
         title={`인증번호가 발송되었어요. (${authCodeData?.requestCount}회 / 하루 최대 3회)`}

--- a/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
@@ -22,24 +22,14 @@ import useAuthCodeTimer from '@/app/join/hooks/useAuthCodeTimer';
 import useSendUnivAuthCodeMutation from '@/app/join/hooks/useSendUnivAuthCodeMutation';
 import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
 
-interface UnivAuthInputProps {
-  isEmailVerified: boolean;
-  handleVerifyEmail: () => void;
-  handleResetVerifyEmail: () => void;
-}
-
 const getButtonText = (isLoading: boolean, isAuthenticated: boolean) => {
   if (isLoading) return '전송 중...';
   if (isAuthenticated) return '수정';
   return '인증번호 전송';
 };
 
-const UnivAuthInput = ({
-  isEmailVerified,
-  handleVerifyEmail,
-  handleResetVerifyEmail,
-}: UnivAuthInputProps) => {
-  const { control } = useFormContext<ResearcherJoinSchemaType>();
+const UnivAuthInput = () => {
+  const { control, setValue, setError } = useFormContext<ResearcherJoinSchemaType>();
 
   const {
     data: authCodeData,
@@ -50,6 +40,8 @@ const UnivAuthInput = ({
 
   const [isEmailSent, setIsEmailSent] = useState(false);
   const [isToastOpen, setIsToastOpen] = useState(false);
+
+  const isEmailVerified = useWatch({ name: 'isEmailVerified', control });
 
   const { authTimer, startTimer, stopTimer } = useAuthCodeTimer();
   const univEmail = useWatch({ name: 'univEmail', control });
@@ -65,7 +57,7 @@ const UnivAuthInput = ({
       },
       onError: (error) => {
         if (error.code === 'VE0007') {
-          handleVerifyEmail();
+          setValue('isEmailVerified', true);
         }
       },
     });
@@ -73,7 +65,7 @@ const UnivAuthInput = ({
 
   const handleClickEdit = () => {
     setIsEmailSent(false);
-    handleResetVerifyEmail();
+    setValue('isEmailVerified', false);
     stopTimer();
   };
 
@@ -89,6 +81,8 @@ const UnivAuthInput = ({
         render={({ field, fieldState }) => {
           const isButtonDisabled =
             (!isEmailSent && !field.value) || isLoadingSend || fieldState.invalid;
+
+          console.log('error:', fieldState.error);
 
           return (
             <>
@@ -121,11 +115,7 @@ const UnivAuthInput = ({
       />
 
       {isEmailSent && (
-        <AuthCodeInput
-          authTimer={authTimer}
-          handleVerifyEmail={handleVerifyEmail}
-          handleSendUnivAuthCode={handleSendUnivAuthCode}
-        />
+        <AuthCodeInput authTimer={authTimer} handleSendUnivAuthCode={handleSendUnivAuthCode} />
       )}
       <EmailToast
         title={`인증번호가 발송되었어요. (${authCodeData?.requestCount}회 / 하루 최대 3회)`}

--- a/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
@@ -29,7 +29,7 @@ const getButtonText = (isLoading: boolean, isAuthenticated: boolean) => {
 };
 
 const UnivAuthInput = () => {
-  const { control, setValue, clearErrors } = useFormContext<ResearcherJoinSchemaType>();
+  const { control, setValue, clearErrors, trigger } = useFormContext<ResearcherJoinSchemaType>();
 
   const {
     data: authCodeData,
@@ -83,7 +83,10 @@ const UnivAuthInput = () => {
           const isButtonDisabled =
             (!isEmailSent && !field.value) || isLoadingSend || fieldState.invalid;
 
-          console.log('error:', fieldState.error);
+          const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+            field.onChange(e);
+            await trigger('univEmail');
+          };
 
           return (
             <>
@@ -95,6 +98,7 @@ const UnivAuthInput = () => {
                   placeholder="학교 메일 입력"
                   aria-invalid={fieldState.invalid ? true : false}
                   disabled={isUnivEmailAuthenticated}
+                  onChange={handleChange}
                 />
                 <button
                   type="button"
@@ -108,7 +112,7 @@ const UnivAuthInput = () => {
               {fieldState.error ? (
                 <span className={errorMessage}>{fieldState.error.message}</span>
               ) : (
-                authCodeError && <span className={errorMessage}>{authCodeError.message}</span>
+                <span className={errorMessage}>{authCodeError && authCodeError.message}</span>
               )}
             </>
           );

--- a/src/app/join/desktop/Researcher/JoinInfoStep/JoinInfoStep.tsx
+++ b/src/app/join/desktop/Researcher/JoinInfoStep/JoinInfoStep.tsx
@@ -2,10 +2,11 @@
 
 import { useFormContext } from 'react-hook-form';
 
+import JoinButton from '../JoinButton/JoinButton';
+
 import JoinInput from '@/app/join/components/JoinInput/JoinInput';
 import { joinContentContainer, joinForm } from '@/app/join/JoinPage.css';
 import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
-import JoinButton from '../JoinButton/JoinButton';
 
 interface JoinInfoStepProps {
   handleSubmit: () => void;

--- a/src/app/join/desktop/Researcher/JoinInfoStep/JoinInfoStep.tsx
+++ b/src/app/join/desktop/Researcher/JoinInfoStep/JoinInfoStep.tsx
@@ -1,27 +1,23 @@
 'use client';
 
-import { useFormContext, useWatch } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 
 import JoinInput from '@/app/join/components/JoinInput/JoinInput';
-import { joinContentContainer, joinForm, nextButton } from '@/app/join/JoinPage.css';
+import { joinContentContainer, joinForm } from '@/app/join/JoinPage.css';
 import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
+import JoinButton from '../JoinButton/JoinButton';
 
 interface JoinInfoStepProps {
   handleSubmit: () => void;
 }
 
 const JoinInfoStep = ({ handleSubmit }: JoinInfoStepProps) => {
-  const {
-    control,
-    formState: { errors },
-  } = useFormContext<ResearcherJoinSchemaType>();
-
-  const values = useWatch({ name: ['name', 'univName', 'major'], control });
-  const isAllFilled = values.every((value) => (value ?? '').trim() !== '' && value !== undefined);
+  const { control } = useFormContext<ResearcherJoinSchemaType>();
 
   return (
     <section className={joinForm}>
       <div className={joinContentContainer}>
+        {/* 이름 */}
         <JoinInput<ResearcherJoinSchemaType>
           name="name"
           control={control}
@@ -29,6 +25,8 @@ const JoinInfoStep = ({ handleSubmit }: JoinInfoStepProps) => {
           required
           placeholder="이름(실명) 입력"
         />
+
+        {/* 학교명 */}
         <JoinInput<ResearcherJoinSchemaType>
           name="univName"
           control={control}
@@ -36,6 +34,8 @@ const JoinInfoStep = ({ handleSubmit }: JoinInfoStepProps) => {
           required
           placeholder="학교명 입력"
         />
+
+        {/* 전공명 */}
         <JoinInput<ResearcherJoinSchemaType>
           name="major"
           control={control}
@@ -43,6 +43,8 @@ const JoinInfoStep = ({ handleSubmit }: JoinInfoStepProps) => {
           required
           placeholder="전공명 입력"
         />
+
+        {/* 소속 연구실 정보 */}
         <JoinInput<ResearcherJoinSchemaType>
           name="labInfo"
           control={control}
@@ -52,13 +54,9 @@ const JoinInfoStep = ({ handleSubmit }: JoinInfoStepProps) => {
           maxLength={100}
         />
       </div>
-      <button
-        className={nextButton}
-        onClick={handleSubmit}
-        disabled={!(isAllFilled && Object.keys(errors).length === 0)}
-      >
-        회원가입
-      </button>
+
+      {/* 회원가입 버튼 */}
+      <JoinButton onSubmit={handleSubmit} />
     </section>
   );
 };

--- a/src/app/join/desktop/Researcher/ResearcherForm.tsx
+++ b/src/app/join/desktop/Researcher/ResearcherForm.tsx
@@ -10,7 +10,11 @@ import { STEP } from '../../JoinPage.constants';
 
 import { Researcher } from '.';
 
-import { ResearcherJoinSchema, ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
+import {
+  ResearcherJoinSchema,
+  ResearcherJoinSchemaType,
+  ResearcherJoinSubmitSchema,
+} from '@/schema/join/ResearcherJoinSchema';
 
 interface ResearcherFormProps {
   onDirtyChange?: (dirty: boolean) => void;
@@ -53,7 +57,9 @@ const ResearcherForm = ({ onDirtyChange }: ResearcherFormProps) => {
 
   const handleResearcherSubmit = () => {
     const formData = researcherMethods.getValues();
-    joinResearcher(formData, { onSuccess: () => setStep(STEP.success) });
+    const submitData = ResearcherJoinSubmitSchema().parse(formData);
+
+    joinResearcher(submitData, { onSuccess: () => setStep(STEP.success) });
   };
 
   return (

--- a/src/app/join/desktop/Researcher/ResearcherForm.tsx
+++ b/src/app/join/desktop/Researcher/ResearcherForm.tsx
@@ -10,8 +10,7 @@ import { STEP } from '../../JoinPage.constants';
 
 import { Researcher } from '.';
 
-import ResearcherJoinSchema, { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
-import { LoginProvider } from '@/types/user';
+import { ResearcherJoinSchema, ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
 
 interface ResearcherFormProps {
   onDirtyChange?: (dirty: boolean) => void;
@@ -33,7 +32,8 @@ const ResearcherForm = ({ onDirtyChange }: ResearcherFormProps) => {
     mode: 'onBlur',
     reValidateMode: 'onChange',
     defaultValues: {
-      oauthEmail: '',
+      oauthEmail,
+      provider,
       contactEmail: '',
       univEmail: '',
       name: '',
@@ -55,13 +55,6 @@ const ResearcherForm = ({ onDirtyChange }: ResearcherFormProps) => {
     const formData = researcherMethods.getValues();
     joinResearcher(formData, { onSuccess: () => setStep(STEP.success) });
   };
-
-  useEffect(() => {
-    if (oauthEmail && provider) {
-      researcherMethods.setValue('oauthEmail', oauthEmail);
-      researcherMethods.setValue('provider', provider as LoginProvider);
-    }
-  }, [researcherMethods, oauthEmail, provider]);
 
   return (
     <FormProvider {...researcherMethods}>

--- a/src/app/join/desktop/Researcher/ResearcherForm.tsx
+++ b/src/app/join/desktop/Researcher/ResearcherForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useSession } from 'next-auth/react';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import JoinSuccessStep from '../../components/JoinSuccessStep/JoinSuccessStep';

--- a/src/app/join/desktop/Researcher/ResearcherForm.tsx
+++ b/src/app/join/desktop/Researcher/ResearcherForm.tsx
@@ -44,6 +44,9 @@ const ResearcherForm = ({ onDirtyChange }: ResearcherFormProps) => {
       univName: '',
       major: '',
       adConsent: false,
+      isTermOfService: false,
+      isPrivacy: false,
+      isEmailVerified: false,
     },
   });
 

--- a/src/app/join/hooks/useCheckValidEmailInfoMutation.ts
+++ b/src/app/join/hooks/useCheckValidEmailInfoMutation.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { validateContactEmailInfo } from '@/apis/login';
+
+const useCheckValidEmailInfoMutation = () => {
+  return useMutation({
+    mutationFn: (contactEmail: string) => validateContactEmailInfo({ contactEmail }),
+  });
+};
+
+export default useCheckValidEmailInfoMutation;

--- a/src/app/user/profile/components/ParticipantUserInfo/ParticipantUserInfo.css.ts
+++ b/src/app/user/profile/components/ParticipantUserInfo/ParticipantUserInfo.css.ts
@@ -15,7 +15,7 @@ export const updateInfoForm = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  gap: '2.8rem',
+  gap: '0.8rem',
   backgroundColor: colors.field02,
   borderRadius: '1.2rem',
   padding: '2.4rem 4rem',

--- a/src/app/user/profile/components/ParticipantUserInfo/ParticipantUserInfo.tsx
+++ b/src/app/user/profile/components/ParticipantUserInfo/ParticipantUserInfo.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useState } from 'react';
-import { Controller } from 'react-hook-form';
+import { Controller, FormProvider } from 'react-hook-form';
 
 import {
   leaveButton,
@@ -49,7 +49,7 @@ const ParticipantUserInfo = ({ userInfo }: { userInfo: ParticipantResponse }) =>
   };
 
   return (
-    <>
+    <FormProvider {...form}>
       <div className={updateInfoFormContainer}>
         <section className={updateInfoForm}>
           {/* 연락 받을 이메일 */}
@@ -182,7 +182,7 @@ const ParticipantUserInfo = ({ userInfo }: { userInfo: ParticipantResponse }) =>
         setIsToastOpen={setIsToastOpen}
         isError={isError}
       />
-    </>
+    </FormProvider>
   );
 };
 

--- a/src/app/user/profile/components/ResearcherUserInfo/ResearcherUserInfo.tsx
+++ b/src/app/user/profile/components/ResearcherUserInfo/ResearcherUserInfo.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useState } from 'react';
-import { Controller } from 'react-hook-form';
+import { Controller, FormProvider } from 'react-hook-form';
 
 import useCheckValidEmailQuery from '../../hooks/useCheckValidEmailQuery';
 import useFormResearcherUserInfo from '../../hooks/useFormResearcherUserInfo';
@@ -43,7 +43,7 @@ const ResearcherUserInfo = ({ userInfo }: { userInfo: ResearcherResponse }) => {
   };
 
   return (
-    <>
+    <FormProvider {...form}>
       <div className={updateInfoFormContainer}>
         <section className={updateInfoForm}>
           {/* 연락 받을 이메일 */}
@@ -144,7 +144,7 @@ const ResearcherUserInfo = ({ userInfo }: { userInfo: ResearcherResponse }) => {
         setIsToastOpen={setIsToastOpen}
         isError={isError}
       />
-    </>
+    </FormProvider>
   );
 };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -50,7 +50,13 @@ export async function middleware(request: NextRequest) {
 
   if (isHomePage) {
     url.pathname = `/home`;
-    return NextResponse.rewrite(url);
+    const response = NextResponse.rewrite(url);
+
+    if (isTempUser) {
+      clearAuthCookies(request, response);
+    }
+
+    return response;
   }
 
   if (isJoinPage || isLoginPage) {

--- a/src/schema/join/ResearcherJoinSchema.ts
+++ b/src/schema/join/ResearcherJoinSchema.ts
@@ -1,52 +1,61 @@
 import { z } from 'zod';
 
 export type ResearcherJoinSchemaType = z.infer<ReturnType<typeof ResearcherJoinSchema>>;
+export type ResearcherJoinSubmitSchemaType = z.infer<ReturnType<typeof ResearcherJoinSubmitSchema>>;
 
-const ResearcherJoinSchema = () => {
-  return z.object({
-    // 소셜 로그인 아이디: 필수. 유저 수정 불가.
-    oauthEmail: z.string().email(),
+const requiredFields = {
+  // 소셜 로그인 아이디: 필수. 유저 수정 불가.
+  oauthEmail: z.string().email(),
 
-    // 소셜 로그인 도메인
-    provider: z.union([z.literal('GOOGLE'), z.literal('NAVER')]),
+  // 소셜 로그인 도메인
+  provider: z.union([z.literal('GOOGLE'), z.literal('NAVER')]),
 
-    // 연락받을 이메일: 필수. 한글X. 이메일 형식.
-    contactEmail: z
-      .string({ required_error: '연락 받을 이메일을 입력해주세요' })
-      .email({ message: '이메일 형식이 올바르지 않아요' }),
+  // 연락받을 이메일: 필수. 한글X. 이메일 형식.
+  contactEmail: z
+    .string({ required_error: '연락 받을 이메일을 입력해주세요' })
+    .email({ message: '이메일 형식이 올바르지 않아요' }),
 
-    // 학교 메일 인증: 필수. 인증 필수.
-    univEmail: z
-      .string({ required_error: '학교 이메일을 입력해주세요' })
-      .email({ message: '이메일 형식이 올바르지 않아요' }),
+  // 학교 메일 인증: 필수. 인증 필수.
+  univEmail: z
+    .string({ required_error: '학교 이메일을 입력해주세요' })
+    .email({ message: '이메일 형식이 올바르지 않아요' }),
 
-    // 이름: 필수. 2자 이상 10자 이하. 한글, 영문만 입력.
-    name: z
-      .string({ required_error: '이름을 입력해 주세요' })
-      .regex(/^[a-zA-Z가-힣]+$/, { message: '한글과 영문만 입력 가능합니다' })
-      .min(2, { message: '최소 2자 이상으로 입력해 주세요' })
-      .max(10, { message: '최대 10자 이하로 입력해 주세요' }),
+  // 이름: 필수. 2자 이상 10자 이하. 한글, 영문만 입력.
+  name: z
+    .string({ required_error: '이름을 입력해 주세요' })
+    .regex(/^[a-zA-Z가-힣]+$/, { message: '한글과 영문만 입력 가능합니다' })
+    .min(2, { message: '최소 2자 이상으로 입력해 주세요' })
+    .max(10, { message: '최대 10자 이하로 입력해 주세요' }),
 
-    // 학교: 필수. 2자 이상 25자 이하.
-    univName: z
-      .string({ required_error: '학교명을 입력해주세요' })
-      .regex(/^[a-zA-Z가-힣]+$/, { message: '한글과 영문만 입력 가능합니다' })
-      .min(2, { message: '최소 2자 이상으로 입력해 주세요' })
-      .max(25, { message: '최대 25자 이하로 입력해 주세요' }),
+  // 학교: 필수. 2자 이상 25자 이하.
+  univName: z
+    .string({ required_error: '학교명을 입력해주세요' })
+    .regex(/^[a-zA-Z가-힣]+$/, { message: '한글과 영문만 입력 가능합니다' })
+    .min(2, { message: '최소 2자 이상으로 입력해 주세요' })
+    .max(25, { message: '최대 25자 이하로 입력해 주세요' }),
 
-    // 학과: 필수. 3자 이상 10자 이하.
-    major: z
-      .string({ required_error: '학과를 입력해주세요' })
-      .regex(/^[a-zA-Z가-힣]+$/, { message: '한글과 영문만 입력 가능합니다' })
-      .min(3, { message: '최소 3자 이상으로 입력해 주세요' })
-      .max(10, { message: '최대 10자 이하로 입력해 주세요' }),
+  // 학과: 필수. 3자 이상 10자 이하.
+  major: z
+    .string({ required_error: '학과를 입력해주세요' })
+    .regex(/^[a-zA-Z가-힣]+$/, { message: '한글과 영문만 입력 가능합니다' })
+    .min(3, { message: '최소 3자 이상으로 입력해 주세요' })
+    .max(10, { message: '최대 10자 이하로 입력해 주세요' }),
 
-    // 랩실정보: 선택. 100자 이하.
-    labInfo: z.string().max(100, { message: '최대 100자 이하로 입력해 주세요' }).optional(),
+  // 랩실정보: 선택. 100자 이하.
+  labInfo: z.string().max(100, { message: '최대 100자 이하로 입력해 주세요' }).optional(),
 
-    // 이메일 수신 동의 체크 여부.
-    adConsent: z.boolean(),
-  });
+  // 이메일 수신 동의 체크 여부.
+  adConsent: z.boolean(),
 };
 
-export default ResearcherJoinSchema;
+export const ResearcherJoinSubmitSchema = () => {
+  return z.object(requiredFields);
+};
+
+export const ResearcherJoinSchema = () => {
+  return z.object({
+    ...requiredFields,
+    isTermOfService: z.boolean(), // 이용약관 동의 여부
+    isPrivacy: z.boolean(), // 개인정보 처리 동의 여부
+  });
+};

--- a/src/schema/join/ResearcherJoinSchema.ts
+++ b/src/schema/join/ResearcherJoinSchema.ts
@@ -57,5 +57,6 @@ export const ResearcherJoinSchema = () => {
     ...requiredFields,
     isTermOfService: z.boolean(), // 이용약관 동의 여부
     isPrivacy: z.boolean(), // 개인정보 처리 동의 여부
+    isEmailVerified: z.boolean(), // 학교 이메일 인증 여부
   });
 };


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->
closed #159 

## As-Is
<!-- 문제 상황 정의 -->
- 연구자 회원가입 시 체크상태나 이메일 인증 여부를 클라이언트 상태로 관리하여 컴포넌트 복잡성 증가
- 연구자 회원가입 시 불필요한 리렌더링 발생
- 입력할 때 전체 페이지가 리렌더링되면서 입력 지연 발생
- 연락 받을 이메일 입력 시 blur 되어야 validation 되는 부분 어색
- 학교 메일 입력 시 blur 되어야 validation 되는 부분 어색
- 연락 받을 이메일 중복 체크 후 변경해도 인증 상태 유지되는 문제
- input 에러 메세지 출력 시 CLS 발생

## To-Be
<!-- 변경 사항 -->
- ResearcherJoinSubmitSchema를 분리하고, step 진행에 필요한 필드값을 RHF로 관리하여 컴포넌트 복잡성 개선 및 렌더링 개선
- 불필요한 formState 참조로 인해 페이지 전체가 리렌더링되는 문제 개선
  - 입력하는 input과 validation 관련된 NextButton, JoinButton에만 리렌더링 발생하도록 개선
- 연락 받을 이메일, 학교 메일 onChange마다 validation 하기 (매번 검증하는 게 성능엔 안좋지만, UX에 이점이 있다고 생각)
- 연락 받을 이메일 중복 체크 후 변경하면 invalid 처리
- input 에러 메세지 출력 시 CLS 개선

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

| AS-IS | TO-BE |
|:-:|:-:|
|<video src='https://github.com/user-attachments/assets/87e3a76b-27bc-4e36-becc-829f22fbfc70' />|<video src='https://github.com/user-attachments/assets/4b04887b-5b24-4a1c-be12-076e12e0891b' />|


## (Optional) Additional Description

React-devTools 를 통해 입력할 때 페이지 전체가 리렌더링되는 현상을 발견하였습니다. 현상을 분석해보니 RHF 특성상 formState를 참조만 해도 같은 Context 내의 Form 데이터를 사용하는 모든 컴포넌트가 리렌더링 되고 있었습니다. formState의 errors를 통해 validation 검증이 있었는데, 이로 인해 전체 페이지가 리렌더링되고 있었습니다. 이를 적절히 컴포넌트를 분리하여 해결하였습니다.

### mode는 onBlur, 학교 메일은 onChange

저희 서비스는 전체적으로 blur 시점에 validation을 검증하는 방식을 채택하고 있습니다. 그래서 useForm의 validation mode를 onBlur로 처리하고 있습니다. 하지만 학교 메일이나 연락받을 이메일 같은 경우 input 위의 Button이 존재합니다. 이런 상황에서는 입력하는 도중에 Button이 적절한 유효성 처리가 되고 있지 않았고, blur가 될 때 fieldState.error가 업데이트되면서 사용자의 예측하기 어려운 동작이 발생합니다. 따라서 약간의 성능적인 문제가 있더라도 onChange마다 trigger를 호출하여 validation이 즉각적으로 이뤄지도록 처리하였습니다. 추후 문제가 될 경우 debounce를 거는 게 최선인 것 같습니다. 다른 방법이 있다면 말씀해주세요!


### 성능 측정

localhost에서 production build 하여 스테이징 서버와 비교한 결과입니다.
측정 과정: CPU x4 쓰로틀링을 걸었고, 연락 받을 이메일과 학교 메일 입력 인증까지 테스트하였습니다.
측정 결과: 브라우저 렌더링 수치는 비슷하지만 `스크립트 실행 수치가 약 20% 개선` 된 것을 확인할 수 있습니다. 리액트 렌더링을 개선했으므로, 내부적으로 계산하는 로직을 줄여 스크립트 수치가 줄어들었으니 실질적인 성능 개선이라고 볼 수 있습니다. 정확히 동일한 환경이라 할 순 없지만 같은 번들링을 거친 소스로 실행시킨 것으로, 거의 유사한 환경에서 측정한 수치를 비교했다고 볼 수 있습니다.

| AS-IS | TO-BE |
|:-:|:-:|
|<img width="790" alt="스테이징-성능-요약" src="https://github.com/user-attachments/assets/fa434575-a0de-49bb-9640-c45f8ad9177e" />|<img width="790" alt="로컬-성능-요약" src="https://github.com/user-attachments/assets/cfcf3dab-5e48-4748-bd2b-f1caf1b010f5" />|




