### PR TITLE
[YS-480] 모바일 헤더의 프로필 아이콘 클릭 시 유저 관련 바텀시트 추가

### DIFF
--- a/src/app/post/[postId]/mobile/ExperimentPostPage.constants.ts
+++ b/src/app/post/[postId]/mobile/ExperimentPostPage.constants.ts
@@ -4,4 +4,5 @@ export const HIDE_MODAL_COOKIE_KEYS: Record<NotReadyMenu, string> = {
   upload: 'hide_upload_modal',
   profile: 'hide_profile_modal',
   edit: 'hide_edit_modal',
+  myPosts: 'hide_my_posts_modal',
 };

--- a/src/app/post/[postId]/mobile/components/EditNotReadyModal/EditNotReadyModal.tsx
+++ b/src/app/post/[postId]/mobile/components/EditNotReadyModal/EditNotReadyModal.tsx
@@ -20,7 +20,7 @@ import NotReadyMobile from '@/assets/images/notReadyMobile.svg';
 import Icon from '@/components/Icon';
 import { setHideModalCookie } from '@/lib/cookies';
 
-export type NotReadyMenu = 'profile' | 'upload' | 'edit';
+export type NotReadyMenu = 'profile' | 'upload' | 'edit' | 'myPosts';
 export interface NotReadyModalProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;

--- a/src/app/post/[postId]/mobile/components/HeaderMenuNotReadyModal/HeaderMenuNotReadyModal.tsx
+++ b/src/app/post/[postId]/mobile/components/HeaderMenuNotReadyModal/HeaderMenuNotReadyModal.tsx
@@ -19,11 +19,29 @@ import {
 import NotReadyMobile from '@/assets/images/notReadyMobile.svg';
 import Icon from '@/components/Icon';
 import { setHideModalCookie } from '@/lib/cookies';
+import { useParams } from 'next/navigation';
 
 //todo NotReadyModal(edit / upload / profile) 공통으로 쓸 수 있게 수정 예정
 // 임시 컴포넌트 위치 변경 예정
 
+const titleMap = {
+  upload: '모바일 버전 글쓰기 화면은 준비 중이에요\nPC에서 더 편리하게 이용하실 수 있어요',
+  profile: '모바일 버전 내 정보 화면은 준비 중이에요\nPC에서 더 편리하게 이용하실 수 있어요',
+  myPosts: '모바일 버전 내가 쓴 글 화면은 준비 중이에요\nPC에서 더 편리하게 이용하실 수 있어요',
+  edit: '모바일 버전 공고 수정 화면은 준비 중이에요\nPC에서 더 편리하게 이용하실 수 있어요',
+};
+
+const menuRouteMap = (id?: string) => ({
+  profile: '/user/profile',
+  upload: '/upload',
+  myPosts: '/my-posts',
+  edit: `/edit/${id}`,
+});
+
 const HeaderMenuNotReadyModal = ({ menu, isOpen, onOpenChange }: NotReadyModalProps) => {
+  const { postId } = useParams();
+  const normalizedPostId = Array.isArray(postId) ? postId[0] : postId;
+
   return (
     <Dialog.Root open={isOpen} onOpenChange={onOpenChange}>
       <Dialog.Portal>
@@ -35,12 +53,7 @@ const HeaderMenuNotReadyModal = ({ menu, isOpen, onOpenChange }: NotReadyModalPr
             </button>
           </Dialog.Close>
 
-          <Dialog.Title className={editModalTitle}>
-            {menu === 'upload' && <div>모바일 버전 글쓰기 화면은 준비 중이에요</div>}
-            {menu === 'profile' && <div>모바일 버전 내 정보 화면은 준비 중이에요</div>}
-            <div>PC에서 더 편리하게 이용하실 수 있어요</div>
-          </Dialog.Title>
-
+          <Dialog.Title className={editModalTitle}>{titleMap[menu]}</Dialog.Title>
           <div className={editModalImage}>
             <Image
               src={NotReadyMobile}
@@ -57,14 +70,14 @@ const HeaderMenuNotReadyModal = ({ menu, isOpen, onOpenChange }: NotReadyModalPr
 
           <Dialog.Close asChild>
             <div className={editModalButtonContainer}>
-              <Link href={menu === 'profile' ? '/user/profile' : '/upload'}>
+              <Link href={menuRouteMap(normalizedPostId)[menu]}>
                 <div className={notReadyButton}>그래도 둘러보기</div>
               </Link>
             </div>
           </Dialog.Close>
           <Dialog.Close asChild>
             <Link
-              href={menu === 'profile' ? '/user/profile' : '/upload'}
+              href={menuRouteMap(normalizedPostId)[menu]}
               onClick={() => {
                 const cookieKey = HIDE_MODAL_COOKIE_KEYS[menu];
                 setHideModalCookie(cookieKey);

--- a/src/app/post/[postId]/mobile/components/HeaderMenuNotReadyModal/HeaderMenuNotReadyModal.tsx
+++ b/src/app/post/[postId]/mobile/components/HeaderMenuNotReadyModal/HeaderMenuNotReadyModal.tsx
@@ -2,6 +2,7 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useParams } from 'next/navigation';
 
 import { HIDE_MODAL_COOKIE_KEYS } from '../../ExperimentPostPage.constants';
 import { NotReadyModalProps } from '../EditNotReadyModal/EditNotReadyModal';
@@ -19,7 +20,6 @@ import {
 import NotReadyMobile from '@/assets/images/notReadyMobile.svg';
 import Icon from '@/components/Icon';
 import { setHideModalCookie } from '@/lib/cookies';
-import { useParams } from 'next/navigation';
 
 //todo NotReadyModal(edit / upload / profile) 공통으로 쓸 수 있게 수정 예정
 // 임시 컴포넌트 위치 변경 예정

--- a/src/components/Header/RightHeader/components/MobileLoginHeader/MobileLoginHeader.tsx
+++ b/src/components/Header/RightHeader/components/MobileLoginHeader/MobileLoginHeader.tsx
@@ -10,6 +10,8 @@ import HeaderMenuNotReadyModal from '@/app/post/[postId]/mobile/components/Heade
 import { HIDE_MODAL_COOKIE_KEYS } from '@/app/post/[postId]/mobile/ExperimentPostPage.constants';
 import Icon from '@/components/Icon';
 import { getHideModalCookie } from '@/lib/cookies';
+import useOverlay from '@/hooks/useOverlay';
+import MypageBottomSheet from './MypageBottomSheet/MypageBottomSheet';
 
 interface MobileLoginHeaderProps {
   isResearcher: boolean;
@@ -20,6 +22,7 @@ const MobileLoginHeader = ({ isResearcher }: MobileLoginHeaderProps) => {
   const [isNotReadyModalOpen, setIsNotReadyModalOpen] = useState(false);
 
   const router = useRouter();
+  const { open, close } = useOverlay();
 
   const handleSelectMenu = (menu: NotReadyMenu) => {
     const cookieKey = HIDE_MODAL_COOKIE_KEYS[menu];
@@ -31,12 +34,24 @@ const MobileLoginHeader = ({ isResearcher }: MobileLoginHeaderProps) => {
         router.push('/user/profile');
       } else if (menu === 'upload') {
         router.push('/upload');
+      } else if (menu === 'myPosts') {
+        router.push('/my-posts');
       }
     } else {
       // 아니면 모달 띄우기
       setSelectedMenu(menu);
       setIsNotReadyModalOpen(true);
     }
+  };
+
+  const handleOpenMypageBottomSheet = () => {
+    open(() => (
+      <MypageBottomSheet
+        isResearcher={isResearcher}
+        handleSelectMenu={handleSelectMenu}
+        onClose={close}
+      />
+    ));
   };
 
   return (
@@ -47,7 +62,7 @@ const MobileLoginHeader = ({ isResearcher }: MobileLoginHeaderProps) => {
             <Icon icon="Pen" width={24} height={24} cursor="pointer" />
           </button>
         )}
-        <button onClick={() => handleSelectMenu('profile')}>
+        <button onClick={handleOpenMypageBottomSheet}>
           <Icon icon="Profile" width={24} height={24} cursor="pointer" />
         </button>
       </div>

--- a/src/components/Header/RightHeader/components/MobileLoginHeader/MobileLoginHeader.tsx
+++ b/src/components/Header/RightHeader/components/MobileLoginHeader/MobileLoginHeader.tsx
@@ -13,30 +13,30 @@ import { getHideModalCookie } from '@/lib/cookies';
 import useOverlay from '@/hooks/useOverlay';
 import MypageBottomSheet from './MypageBottomSheet/MypageBottomSheet';
 
+const routeMap = {
+  profile: '/user/profile',
+  upload: '/upload',
+  myPosts: '/my-posts',
+};
+
 interface MobileLoginHeaderProps {
   isResearcher: boolean;
 }
 
 const MobileLoginHeader = ({ isResearcher }: MobileLoginHeaderProps) => {
-  const [selectedMenu, setSelectedMenu] = useState<NotReadyMenu>('upload');
+  const [selectedMenu, setSelectedMenu] = useState<Exclude<NotReadyMenu, 'edit'>>('upload');
   const [isNotReadyModalOpen, setIsNotReadyModalOpen] = useState(false);
 
   const router = useRouter();
   const { open, close } = useOverlay();
 
-  const handleSelectMenu = (menu: NotReadyMenu) => {
+  const handleSelectMenu = (menu: Exclude<NotReadyMenu, 'edit'>) => {
     const cookieKey = HIDE_MODAL_COOKIE_KEYS[menu];
     const shouldSkipModal = getHideModalCookie(cookieKey);
 
     if (shouldSkipModal) {
       //  하루동안 안보기 선택된 경우
-      if (menu === 'profile') {
-        router.push('/user/profile');
-      } else if (menu === 'upload') {
-        router.push('/upload');
-      } else if (menu === 'myPosts') {
-        router.push('/my-posts');
-      }
+      router.push(routeMap[menu]);
     } else {
       // 아니면 모달 띄우기
       setSelectedMenu(menu);

--- a/src/components/Header/RightHeader/components/MobileLoginHeader/MobileLoginHeader.tsx
+++ b/src/components/Header/RightHeader/components/MobileLoginHeader/MobileLoginHeader.tsx
@@ -4,14 +4,14 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 import { mobileRightHeader } from './MobileLoginHeader.css';
+import MypageBottomSheet from './MypageBottomSheet/MypageBottomSheet';
 
 import { NotReadyMenu } from '@/app/post/[postId]/mobile/components/EditNotReadyModal/EditNotReadyModal';
 import HeaderMenuNotReadyModal from '@/app/post/[postId]/mobile/components/HeaderMenuNotReadyModal/HeaderMenuNotReadyModal';
 import { HIDE_MODAL_COOKIE_KEYS } from '@/app/post/[postId]/mobile/ExperimentPostPage.constants';
 import Icon from '@/components/Icon';
-import { getHideModalCookie } from '@/lib/cookies';
 import useOverlay from '@/hooks/useOverlay';
-import MypageBottomSheet from './MypageBottomSheet/MypageBottomSheet';
+import { getHideModalCookie } from '@/lib/cookies';
 
 const routeMap = {
   profile: '/user/profile',

--- a/src/components/Header/RightHeader/components/MobileLoginHeader/MypageBottomSheet/MypageBottomSheet.css.ts
+++ b/src/components/Header/RightHeader/components/MobileLoginHeader/MypageBottomSheet/MypageBottomSheet.css.ts
@@ -1,6 +1,7 @@
+import { style } from '@vanilla-extract/css';
+
 import { colors } from '@/styles/colors';
 import { fonts } from '@/styles/fonts.css';
-import { style } from '@vanilla-extract/css';
 
 export const mypageBottomSheetLayout = style({
   display: 'flex',

--- a/src/components/Header/RightHeader/components/MobileLoginHeader/MypageBottomSheet/MypageBottomSheet.css.ts
+++ b/src/components/Header/RightHeader/components/MobileLoginHeader/MypageBottomSheet/MypageBottomSheet.css.ts
@@ -1,0 +1,18 @@
+import { colors } from '@/styles/colors';
+import { fonts } from '@/styles/fonts.css';
+import { style } from '@vanilla-extract/css';
+
+export const mypageBottomSheetLayout = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+});
+
+export const listItem = style({
+  ...fonts.body.small.M15,
+  color: colors.text06,
+  width: '100%',
+  display: 'flex',
+  padding: '1.4rem 0',
+  alignItems: 'center',
+});

--- a/src/components/Header/RightHeader/components/MobileLoginHeader/MypageBottomSheet/MypageBottomSheet.tsx
+++ b/src/components/Header/RightHeader/components/MobileLoginHeader/MypageBottomSheet/MypageBottomSheet.tsx
@@ -1,6 +1,7 @@
+import { listItem, mypageBottomSheetLayout } from './MypageBottomSheet.css';
+
 import { logout } from '@/lib/auth-utils';
 import { logoutUser } from '@/lib/mixpanelClient';
-import { listItem, mypageBottomSheetLayout } from './MypageBottomSheet.css';
 
 type NotReadyMenu = 'profile' | 'upload' | 'edit' | 'myPosts';
 

--- a/src/components/Header/RightHeader/components/MobileLoginHeader/MypageBottomSheet/MypageBottomSheet.tsx
+++ b/src/components/Header/RightHeader/components/MobileLoginHeader/MypageBottomSheet/MypageBottomSheet.tsx
@@ -12,13 +12,13 @@ interface MypageBottomSheetProps {
 
 const MypageBottomSheet = ({ isResearcher, handleSelectMenu, onClose }: MypageBottomSheetProps) => {
   const handleClickProfile = () => {
-    handleSelectMenu('profile');
     onClose();
+    handleSelectMenu('profile');
   };
 
   const handleClickMyPosts = () => {
-    handleSelectMenu('myPosts');
     onClose();
+    handleSelectMenu('myPosts');
   };
 
   const handleLogout = async () => {

--- a/src/components/Header/RightHeader/components/MobileLoginHeader/MypageBottomSheet/MypageBottomSheet.tsx
+++ b/src/components/Header/RightHeader/components/MobileLoginHeader/MypageBottomSheet/MypageBottomSheet.tsx
@@ -6,7 +6,7 @@ type NotReadyMenu = 'profile' | 'upload' | 'edit' | 'myPosts';
 
 interface MypageBottomSheetProps {
   isResearcher: boolean;
-  handleSelectMenu: (menu: NotReadyMenu) => void;
+  handleSelectMenu: (menu: Exclude<NotReadyMenu, 'edit'>) => void;
   onClose: () => void;
 }
 

--- a/src/components/Header/RightHeader/components/MobileLoginHeader/MypageBottomSheet/MypageBottomSheet.tsx
+++ b/src/components/Header/RightHeader/components/MobileLoginHeader/MypageBottomSheet/MypageBottomSheet.tsx
@@ -1,0 +1,48 @@
+import { logout } from '@/lib/auth-utils';
+import { logoutUser } from '@/lib/mixpanelClient';
+import { listItem, mypageBottomSheetLayout } from './MypageBottomSheet.css';
+
+type NotReadyMenu = 'profile' | 'upload' | 'edit' | 'myPosts';
+
+interface MypageBottomSheetProps {
+  isResearcher: boolean;
+  handleSelectMenu: (menu: NotReadyMenu) => void;
+  onClose: () => void;
+}
+
+const MypageBottomSheet = ({ isResearcher, handleSelectMenu, onClose }: MypageBottomSheetProps) => {
+  const handleClickProfile = () => {
+    handleSelectMenu('profile');
+    onClose();
+  };
+
+  const handleClickMyPosts = () => {
+    handleSelectMenu('myPosts');
+    onClose();
+  };
+
+  const handleLogout = async () => {
+    onClose();
+    logoutUser();
+    await logout();
+  };
+
+  return (
+    <section className={mypageBottomSheetLayout}>
+      <button className={listItem} onClick={handleClickProfile}>
+        내 정보
+      </button>
+
+      {isResearcher && (
+        <button className={listItem} onClick={handleClickMyPosts}>
+          내가 쓴 글
+        </button>
+      )}
+      <button className={listItem} onClick={handleLogout}>
+        로그아웃
+      </button>
+    </section>
+  );
+};
+
+export default MypageBottomSheet;


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->
closed #175 

## As-Is
<!-- 문제 상황 정의 -->
- 모바일 프로필을 클릭했을 때 바로 모달 노출

## To-Be
<!-- 변경 사항 -->
- 모바일 프로필 클릭 시 바텀시트 노출 후 메뉴에 따라 다른 텍스트로 모달 노출
- MypageBottomSheet 구현
- 일부 복잡한 분기처리 객체 맵핑으로 변경

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/9a3d37af-cf1e-4ca2-aafd-9e5a4e124761

## (Optional) Additional Description

객체로 변경한 부분 확인 부탁드려요! NotReadyMenu가 전혀 다른 곳에 있어서 새로 만들었는데, export한 걸 여러곳에서 import 했을 때 번들링에 불리하다는 글을 봐서 별도로 만들었는데 확인 부탁드려요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 모바일 환경에서 프로필 버튼 클릭 시, 하단 시트 메뉴(마이페이지 바텀시트)가 열리도록 개선되었습니다.
  - 마이페이지 바텀시트에서 "내 정보", "내가 쓴 글"(연구자일 경우), "로그아웃" 메뉴를 사용할 수 있습니다.

- **스타일**
  - 마이페이지 바텀시트 전용 스타일이 추가되어, 보다 일관된 디자인을 제공합니다.

- **기타**
  - "내가 쓴 글" 관련 모달 및 메뉴 항목이 추가되어, 관련 기능 접근성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->