### PR TITLE
[YS-497] 공고 상세 태블릿 사이즈 스크롤 처리 및 반응형 스타일 수정

### DIFF
--- a/src/app/post/[postId]/desktop/components/ExperimentPostContainer/ExperimentPostContainer.css.ts
+++ b/src/app/post/[postId]/desktop/components/ExperimentPostContainer/ExperimentPostContainer.css.ts
@@ -10,7 +10,7 @@ export const postContentLayout = style({
   position: 'relative',
 
   '@media': {
-    'screen and (max-width: 1023px)': {
+    'screen and (max-width: 767px)': {
       display: 'flex',
       flexFlow: 'column nowrap',
     },

--- a/src/app/post/[postId]/desktop/components/ExperimentPostDetailContent/ExperimentPostDetailContent.css.ts
+++ b/src/app/post/[postId]/desktop/components/ExperimentPostDetailContent/ExperimentPostDetailContent.css.ts
@@ -13,6 +13,10 @@ export const postDetailContentLayout = style({
 
   '@media': {
     'screen and (max-width: 1023px)': {
+      minWidth: '60.8rem',
+    },
+
+    'screen and (max-width: 767px)': {
       minWidth: '36rem',
     },
   },

--- a/src/app/post/[postId]/desktop/components/ExperimentPostOutline/ExperimentPostOutline.css.ts
+++ b/src/app/post/[postId]/desktop/components/ExperimentPostOutline/ExperimentPostOutline.css.ts
@@ -5,7 +5,7 @@ import { colors } from '@/styles/colors';
 import { fonts } from '@/styles/fonts.css';
 
 export const postOutlineLayout = style({
-  minWidth: '36rem',
+  minWidth: '34rem',
   height: 'min-content',
   maxHeight: '60rem',
   borderRadius: '1.2rem',

--- a/src/components/layout/DefaultLayout/DefaultLayout.css.ts
+++ b/src/components/layout/DefaultLayout/DefaultLayout.css.ts
@@ -22,9 +22,12 @@ export const defaultLayoutContainer = style({
 export const defaultLayout = style({
   width: '100rem',
   margin: '0 auto',
-  padding: '0 2rem',
 
   '@media': {
+    'screen and (max-width: 1023px)': {
+      padding: '0 2rem',
+    },
+
     'screen and (max-width: 767px)': {
       width: '100%',
       padding: '0',


### PR DESCRIPTION
## Issue Number
close #179 
<!-- #이슈번호 -->

## As-Is
<!-- 문제 상황 정의 -->

공고 상세일 때 태블릿 사이즈 (767px~1000px 구간)일 때 데스크탑 디자인으로 스크롤 처리 x

## To-Be
<!-- 변경 사항 -->

공고 상세일 때 태블릿 사이즈 (767px~1000px 구간)일 때 데스크탑 디자인으로 스크롤 처리

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
![공고상세_태블릿](https://github.com/user-attachments/assets/11b3439a-daa7-4e3a-897a-93b4680d19aa)



## (Optional) Additional Description
홈화면과 마찬가지로 767px~1000px 구간에서는 데스크탑 디자인이 스크롤로 보이게 처리 했어야 했는데 놓쳐서 추가했습니다!
그리고 저 구간에서 양옆 여백이 없으면 너무 화면 끝과 맞닿아있어서 padding 적용하였습니다.

