### PR TITLE
[YS-500] Footer 컴포넌트 위치 이동 및 전반적인 레이아웃 수정

### DIFF
--- a/src/app/home/components/ExperimentPostContainer/ExperimentPostContainer.css.ts
+++ b/src/app/home/components/ExperimentPostContainer/ExperimentPostContainer.css.ts
@@ -12,10 +12,13 @@ export const postContainerLayout = style({
 
   background: 'transparent',
 
+  paddingBottom: '12.2rem', // footer
+
   '@media': {
     'screen and (max-width: 767px)': {
       marginTop: '0',
       gap: '0',
+      paddingBottom: '0',
     },
   },
 });

--- a/src/app/join/JoinPage.css.ts
+++ b/src/app/join/JoinPage.css.ts
@@ -6,10 +6,17 @@ import { fonts } from '@/styles/fonts.css';
 export const desktopJoinPageLayout = style({
   display: 'flex',
   backgroundColor: colors.field01,
-  width: '56rem',
-  minHeight: 'calc(100vh - 12.2rem)',
+  maxWidth: '56rem',
+  width: '100%',
   margin: '0 auto',
-  padding: '8rem 0',
+  paddingTop: '8rem',
+  paddingBottom: '20.2rem', // 12. 2 (footer) + 8 (footer와 버튼 사이 여백)
+
+  '@media': {
+    'screen and (max-width: 767px)': {
+      paddingBottom: '8rem',
+    },
+  },
 });
 
 export const mobileJoinPageLayout = style({

--- a/src/app/join/desktop/layout.tsx
+++ b/src/app/join/desktop/layout.tsx
@@ -1,5 +1,11 @@
 import { desktopJoinPageLayout } from '../JoinPage.css';
 
+import Footer from '@/components/Footer/Footer';
+
 export default function DesktopJoinLayout({ children }: { children: React.ReactNode }) {
-  return <div className={desktopJoinPageLayout}>{children} </div>;
+  return (
+    <div className={desktopJoinPageLayout}>
+      {children} <Footer />
+    </div>
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import { getServerSession } from 'next-auth';
 
-import Footer from '@/components/Footer/Footer';
 import pretendard from '@/fonts/local-font';
 import '@/styles/reset.css';
 import '@/styles/global.css';
@@ -61,10 +60,7 @@ export default async function RootLayout({
   return (
     <html lang="ko" className={pretendard.className}>
       <body suppressHydrationWarning={true}>
-        <Providers session={session}>
-          {children}
-          <Footer />
-        </Providers>
+        <Providers session={session}>{children}</Providers>
       </body>
     </html>
   );

--- a/src/app/login/LoginPage.css.ts
+++ b/src/app/login/LoginPage.css.ts
@@ -9,6 +9,8 @@ export const loginLayout = style({
   paddingBottom: '20.6rem', // 12.2 + 8.4rem
   backgroundColor: colors.field01,
 
+  minHeight: '100vh',
+
   '@media': {
     'screen and (max-width: 767px)': {
       paddingBottom: '8.4rem',

--- a/src/app/login/LoginPage.css.ts
+++ b/src/app/login/LoginPage.css.ts
@@ -4,21 +4,30 @@ import { colors } from '@/styles/colors';
 import { fonts } from '@/styles/fonts.css';
 
 export const loginLayout = style({
+  position: 'relative',
+  paddingTop: '8.4rem',
+  paddingBottom: '20.6rem', // 12.2 + 8.4rem
+  backgroundColor: colors.field01,
+
+  '@media': {
+    'screen and (max-width: 767px)': {
+      paddingBottom: '8.4rem',
+    },
+  },
+});
+
+export const contentLayout = style({
+  maxWidth: '56rem',
+  margin: '0 auto',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  justifyContent: 'center',
-  backgroundColor: colors.field01,
-  minWidth: '100rem',
-  margin: '0 auto',
-  padding: '8.4rem 0',
 });
 
 export const loginPageLayout = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '6.5rem',
-  minHeight: 'calc(100vh - 29rem)', // 29rem = footer(12.2rem) + padding 위/아래 (8.4rem * 2)
 });
 
 export const descriptionWrapper = style({

--- a/src/app/login/desktop/layout.tsx
+++ b/src/app/login/desktop/layout.tsx
@@ -1,7 +1,9 @@
 import { Metadata } from 'next';
 
 import LoginError from '../components/LoginError/LoginError';
-import { loginLayout } from '../LoginPage.css';
+import { contentLayout, loginLayout } from '../LoginPage.css';
+
+import Footer from '@/components/Footer/Footer';
 
 export const metadata: Metadata = {
   title: '그라밋 | 로그인',
@@ -11,7 +13,10 @@ export const metadata: Metadata = {
 export default function DesktopLoginLayout({ children }: { children: React.ReactNode }) {
   return (
     <LoginError>
-      <div className={loginLayout}>{children}</div>
+      <div className={loginLayout}>
+        <main className={contentLayout}>{children}</main>
+        <Footer />
+      </div>
     </LoginError>
   );
 }

--- a/src/app/my-posts/MyPostsPage.css.ts
+++ b/src/app/my-posts/MyPostsPage.css.ts
@@ -3,12 +3,27 @@ import { style } from '@vanilla-extract/css';
 import { colors } from '@/styles/colors';
 
 export const myPostsLayoutContainer = style({
-  width: 'fit-content',
-  margin: '0 auto',
+  width: '100%',
   backgroundColor: colors.field01,
-  paddingBottom: '5.6rem',
+  padding: '0 2rem',
+
+  paddingBottom: '17.8rem', // 12.2 + 5.6
+
+  '@media': {
+    'screen and (max-width: 1023px)': {
+      width: 'max-content',
+    },
+
+    'screen and (max-width: 767px)': {
+      width: '100%',
+      paddingBottom: '5.6rem',
+    },
+  },
+  position: 'relative',
+  overflowX: 'auto',
 });
 
 export const myPostsLayout = style({
   width: '100rem',
+  margin: '0 auto',
 });

--- a/src/app/my-posts/layout.tsx
+++ b/src/app/my-posts/layout.tsx
@@ -3,8 +3,8 @@ import { PropsWithChildren } from 'react';
 
 import { myPostsLayout, myPostsLayoutContainer } from './MyPostsPage.css';
 
-import Header from '@/components/Header/Header';
 import Footer from '@/components/Footer/Footer';
+import Header from '@/components/Header/Header';
 
 export const metadata: Metadata = {
   title: '그라밋 | 작성 글 목록',

--- a/src/app/my-posts/layout.tsx
+++ b/src/app/my-posts/layout.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren } from 'react';
 import { myPostsLayout, myPostsLayoutContainer } from './MyPostsPage.css';
 
 import Header from '@/components/Header/Header';
+import Footer from '@/components/Footer/Footer';
 
 export const metadata: Metadata = {
   title: '그라밋 | 작성 글 목록',
@@ -17,6 +18,7 @@ function MyPostsLayout({ children }: PropsWithChildren) {
         <Header />
         {children}
       </div>
+      <Footer />
     </div>
   );
 }

--- a/src/app/post/[postId]/desktop/components/ExperimentPostContainer/ExperimentPostContainer.css.ts
+++ b/src/app/post/[postId]/desktop/components/ExperimentPostContainer/ExperimentPostContainer.css.ts
@@ -8,17 +8,20 @@ export const postContentLayout = style({
   marginBottom: '6rem',
   borderRadius: '1.2rem',
   position: 'relative',
+  paddingBottom: '8.4rem',
 
   '@media': {
     'screen and (max-width: 767px)': {
       display: 'flex',
       flexFlow: 'column nowrap',
+      paddingBottom: '0',
     },
   },
 });
 
 export const emptyViewLayout = style({
-  height: 'calc(100vh - 25rem)',
+  height: 'calc(100vh - 12.8rem)', // 25 - 12.2
+
   display: 'flex',
   flexFlow: 'column nowrap',
   justifyContent: 'center',

--- a/src/app/post/[postId]/desktop/components/ExperimentPostDetailContent/ExperimentPostDetailContent.css.ts
+++ b/src/app/post/[postId]/desktop/components/ExperimentPostDetailContent/ExperimentPostDetailContent.css.ts
@@ -80,6 +80,10 @@ export const multiImageGrid = style({
   gap: '1.6rem',
 
   '@media': {
+    'screen and (max-width: 1023px)': {
+      gridTemplateColumns: 'repeat(3, 1fr)',
+    },
+
     'screen and (max-width: 767px)': {
       gridTemplateColumns: 'repeat(2, 1fr)',
     },

--- a/src/app/post/[postId]/desktop/components/ExperimentPostOutline/ExperimentPostOutline.css.ts
+++ b/src/app/post/[postId]/desktop/components/ExperimentPostOutline/ExperimentPostOutline.css.ts
@@ -11,7 +11,7 @@ export const postOutlineLayout = style({
   borderRadius: '1.2rem',
   backgroundColor: colors.field01,
   position: 'sticky',
-  top: '12rem',
+  top: '0',
   padding: '2.4rem 3rem 0 3rem',
   display: 'flex',
   flexDirection: 'column',

--- a/src/app/upload/components/DescriptionSection/DescriptionSection.css.ts
+++ b/src/app/upload/components/DescriptionSection/DescriptionSection.css.ts
@@ -19,7 +19,8 @@ export const descriptionFormLayout = style({
 
 export const descriptionContentContainer = recipe({
   base: {
-    width: '93.6rem',
+    maxWidth: '93.6rem',
+    width: '100%',
     border: `0.1rem solid ${colors.line01}`,
     borderRadius: '1.2rem',
     ':focus-within': {

--- a/src/app/upload/components/UploadContainer/UploadContainer.css.ts
+++ b/src/app/upload/components/UploadContainer/UploadContainer.css.ts
@@ -9,6 +9,8 @@ export const uploadLayout = style({
   gap: '4rem',
   color: colors.text06,
   marginTop: '1.6rem',
+
+  paddingBottom: '12.2rem', // footer
 });
 
 export const headerTitle = style({

--- a/src/app/user/leave/LeavePage.css.ts
+++ b/src/app/user/leave/LeavePage.css.ts
@@ -5,8 +5,19 @@ import { fonts } from '@/styles/fonts.css';
 
 export const leavePageLayout = style({
   display: 'flex',
-  width: '56rem',
+  maxWidth: '56rem',
+
+  width: '100%',
+
   margin: '0 auto',
+
+  paddingBottom: '17.8rem', // 12.2 + 5.6
+
+  '@media': {
+    'screen and (max-width: 767px)': {
+      padding: '0 2rem 5.6rem',
+    },
+  },
 });
 
 export const leaveFormLayout = style({

--- a/src/app/user/leave/layout.tsx
+++ b/src/app/user/leave/layout.tsx
@@ -1,6 +1,6 @@
-import Footer from '@/components/Footer/Footer';
 import { leavePageLayout } from './LeavePage.css';
 
+import Footer from '@/components/Footer/Footer';
 import UserLayout from '@/components/layout/UserLayout/UserLayout';
 
 function LeaveLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/user/leave/layout.tsx
+++ b/src/app/user/leave/layout.tsx
@@ -1,3 +1,4 @@
+import Footer from '@/components/Footer/Footer';
 import { leavePageLayout } from './LeavePage.css';
 
 import UserLayout from '@/components/layout/UserLayout/UserLayout';
@@ -6,6 +7,7 @@ function LeaveLayout({ children }: { children: React.ReactNode }) {
   return (
     <UserLayout>
       <div className={leavePageLayout}>{children}</div>
+      <Footer />
     </UserLayout>
   );
 }

--- a/src/app/user/profile/ProfilePage.css.ts
+++ b/src/app/user/profile/ProfilePage.css.ts
@@ -2,9 +2,20 @@ import { style } from '@vanilla-extract/css';
 
 export const profilePageLayout = style({
   display: 'flex',
-  width: '56rem',
+  maxWidth: '56rem',
+
+  width: '100%',
+
   margin: '0 auto',
   minHeight: 'calc(100vh - 12.2rem)',
+
+  paddingBottom: '18.2rem', // 12.2 + 6
+
+  '@media': {
+    'screen and (max-width: 767px)': {
+      paddingBottom: '6rem',
+    },
+  },
 });
 
 export const joinLayout = style({

--- a/src/app/user/profile/ProfilePage.css.ts
+++ b/src/app/user/profile/ProfilePage.css.ts
@@ -12,6 +12,10 @@ export const profilePageLayout = style({
   paddingBottom: '18.2rem', // 12.2 + 6
 
   '@media': {
+    'screen and (max-width: 1023px)': {
+      padding: '0 2rem 18.2rem',
+    },
+
     'screen and (max-width: 767px)': {
       paddingBottom: '6rem',
     },

--- a/src/app/user/profile/layout.tsx
+++ b/src/app/user/profile/layout.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next';
 import { profilePageLayout } from './ProfilePage.css';
 
 import UserLayout from '@/components/layout/UserLayout/UserLayout';
+import Footer from '@/components/Footer/Footer';
 
 export const metadata: Metadata = {
   title: '그라밋 | 회원 정보',
@@ -13,6 +14,7 @@ function ProfileLayout({ children }: { children: React.ReactNode }) {
   return (
     <UserLayout>
       <div className={profilePageLayout}>{children}</div>
+      <Footer />
     </UserLayout>
   );
 }

--- a/src/app/user/profile/layout.tsx
+++ b/src/app/user/profile/layout.tsx
@@ -2,8 +2,8 @@ import { Metadata } from 'next';
 
 import { profilePageLayout } from './ProfilePage.css';
 
-import UserLayout from '@/components/layout/UserLayout/UserLayout';
 import Footer from '@/components/Footer/Footer';
+import UserLayout from '@/components/layout/UserLayout/UserLayout';
 
 export const metadata: Metadata = {
   title: '그라밋 | 회원 정보',

--- a/src/components/Footer/Footer.css.ts
+++ b/src/components/Footer/Footer.css.ts
@@ -11,6 +11,12 @@ export const footerLayout = style({
   justifyContent: 'center',
   gap: '1.6rem',
   padding: '2rem 0',
+  width: '100%',
+
+  position: 'absolute',
+  // position: 'fixed',
+  left: 0,
+  bottom: 0,
 
   '@media': {
     'screen and (max-width: 767px)': {

--- a/src/components/layout/DefaultLayout/DefaultLayout.css.ts
+++ b/src/components/layout/DefaultLayout/DefaultLayout.css.ts
@@ -8,10 +8,13 @@ export const defaultLayoutContainer = style({
   minHeight: 'calc(100vh - 12.2rem)',
   background: `linear-gradient(to bottom, ${colors.field01} 0%, ${colors.field01} 6%, ${colors.field02} 12%, ${colors.field02} 100%)`,
 
-  overflowX: 'auto',
-
   '@media': {
+    'screen and (max-width: 1023px)': {
+      width: 'max-content',
+    },
+
     'screen and (max-width: 767px)': {
+      width: 'auto',
       minHeight: '100dvh',
       paddingBottom: '0',
       background: colors.field01,

--- a/src/components/layout/DefaultLayout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout/DefaultLayout.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren } from 'react';
 import { defaultLayout, defaultLayoutContainer } from './DefaultLayout.css';
 
 import BackToTopButton from '@/components/Button/BackToTopButton/BackToTopButton';
+import Footer from '@/components/Footer/Footer';
 import Header from '@/components/Header/Header';
 
 const DefaultLayout = ({ children }: PropsWithChildren) => {
@@ -11,6 +12,7 @@ const DefaultLayout = ({ children }: PropsWithChildren) => {
       <div className={defaultLayout}>
         <Header />
         {children}
+        <Footer />
         <BackToTopButton />
       </div>
     </div>

--- a/src/components/layout/UserLayout/UserLayout.css.ts
+++ b/src/components/layout/UserLayout/UserLayout.css.ts
@@ -9,6 +9,15 @@ export const userLayoutContainer = style({
 
   margin: '0 auto',
   minHeight: 'calc(100vh - 12.2rem)',
+
+  '@media': {
+    'screen and (max-width: 1023px)': {
+      padding: '0 2rem',
+    },
+    'screen and (max-width: 767px)': {
+      padding: '0',
+    },
+  },
 });
 
 export const userLayout = style({

--- a/src/components/layout/UserLayout/UserLayout.css.ts
+++ b/src/components/layout/UserLayout/UserLayout.css.ts
@@ -4,12 +4,14 @@ import { colors } from '@/styles/colors';
 
 export const userLayoutContainer = style({
   backgroundColor: colors.field01,
-  paddingBottom: '5.6rem',
+  maxWidth: '100rem',
+  width: '100%',
+
+  margin: '0 auto',
   minHeight: 'calc(100vh - 12.2rem)',
 });
 
 export const userLayout = style({
-  width: '100rem',
   margin: '0 auto',
   backgroundColor: colors.field01,
 });


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->

close #185 

## As-Is
<!-- 문제 상황 정의 -->

- 767px - 1000px 구간에 스크롤 처리를 하기 위해 `overflow: auto`를 적용하자
공고 상세에서 실험 개요 컴포넌트 `position: sticky`가 적용이 안됨.
- 스크롤 시 `Footer`는 스크롤 되지 않고 고정됨.


## To-Be
<!-- 변경 사항 -->
해당 이슈를 해결하기 위해 전반적인 레이아웃 스타일을 수정함.
루트 레이아웃에서 `Footer`를 제거하고 각 레이아웃마다 `Footer`를 추가함.
그에 따른 레이아웃 및 디테일한 스타일 수정 진행.

- 767px - 1000px 구간엔 스크롤 적용 o (해당 구간을 간결하게 태블릿 사이즈라고 칭함)
- 푸터 역시 해당 구간에 스크롤 적용 o
- 공고 상세에서 실험 개요 컴포넌트 sticky 적용 o (데스크탑)
 
 


## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
| 기존 스크롤 실험 개요 | 수정 스크롤 실험 개요 |
|----------------------|------------------------|
| ![기존_태블릿_스크롤](https://github.com/user-attachments/assets/1030fffd-ece1-436d-805f-9acac21a4878) | ![수정_태블릿_스크롤](https://github.com/user-attachments/assets/ac775b0a-19b8-42e3-99f7-f15eb199e662) |


## (Optional) Additional Description

`100rem`으로 고정되는 컨텐츠 영역과 달리 `Footer` 영역은 화면 전체를 차지해야 해서 기존엔 루트 레이아웃에 `Footer`가 존재하였습니다. 
하지만 기존 구조로는 여러 방법을 시도해도 스크롤(overflow)과 실험 개요 컴포넌트 sticky 동시 적용이 어려워 기존 레이아웃 구조를 변경하였습니다. -> 루트 레이아웃에서 `Footer`를 제거하여 `defaultLayout`을 비롯한 각 레이아웃에 추가

Footer의 경우 모바일 사이즈에선 숨겨야 하므로 그에 따른 반응형 스타일을 추가하였고 기존 디자인을 유지하기 위해 여러 곳에서 스타일을 수정하였습니다.

- 공통적으로는 태블릿 사이즈 이하의 화면에서는 꽉 차지 않게 `padding: 0 2rem`을 적용하였습니다. 
- 최대한 기존 디자인을 유지도록 체크하였으나 누락된 곳이 있을 수 있으니 규한님 파트는 한번 더 확인해주세요! (스타일이나 레이아웃 깨짐이 있는는지..)
- 유지보수를 고려하며 코드를 수정하려고 했지만,,, 이미 저희 둘이 적용해 놓은 스타일 방식에서의 차이도 컸고 페이지마다 / 화면 사이즈마다 조금씩 레이아웃이나 스타일에서의 차이가 존재하여 쉽지 않았습니다 ㅠ_ㅠ... 코드만 봤을 때는 이해하기 어려울 거 같아 UI 위주로 스타일이 기존과 달라졌거나 깨지는 부분이 있는지 확인 부탁드립니다!!


