### PR TITLE
[YS-501] 저사양 환경에서 발생하는 입력 지연을 useTransition을 활용하여 INP 개선

### DIFF
--- a/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
+++ b/src/app/join/desktop/Researcher/JoinEmailStep/UnivAuthInput/UnivAuthInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 
 import AuthCodeInput from './AuthCodeInput/AuthCodeInput';
@@ -37,6 +37,7 @@ const UnivAuthInput = () => {
     error: authCodeError,
     isPending: isLoadingSend,
   } = useSendUnivAuthCodeMutation();
+  const [_, startTransition] = useTransition();
 
   const [isEmailSent, setIsEmailSent] = useState(false);
   const [isToastOpen, setIsToastOpen] = useState(false);
@@ -85,7 +86,10 @@ const UnivAuthInput = () => {
 
           const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
             field.onChange(e);
-            await trigger('univEmail');
+
+            startTransition(() => {
+              trigger('univEmail');
+            });
           };
 
           return (

--- a/src/app/join/hooks/useFunnel.tsx
+++ b/src/app/join/hooks/useFunnel.tsx
@@ -19,14 +19,14 @@ interface FunnelProps {
 const useFunnel = <Steps extends StepsType>(steps: Steps) => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const currentStep = searchParams.get('step') || steps?.[0] || DEFAULT_STEP;
+  const currentStep = searchParams.get('step') ?? steps?.[0] ?? DEFAULT_STEP;
 
   const currentStepIdx = useMemo(
-    () => steps.findIndex((step) => step === currentStep),
+    () => steps?.findIndex((step) => step === currentStep) ?? 0,
     [steps, currentStep],
   );
 
-  const isLast = currentStepIdx === steps.length - 1;
+  const isLast = currentStepIdx === (Array.isArray(steps) ? steps.length - 1 : 0);
 
   const setStep = (step: string) => {
     router.push(`?step=${step}`);

--- a/src/app/join/mobile/Researcher/UnivEmailInputContainer/UnivEmailInputContainer.tsx
+++ b/src/app/join/mobile/Researcher/UnivEmailInputContainer/UnivEmailInputContainer.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 
 import {
@@ -40,6 +40,7 @@ const UnivEmailInputContainer = ({ openServiceAgreeBottomSheet }: UnivEmailInput
     error: authCodeError,
     isPending: isLoadingSend,
   } = useSendUnivAuthCodeMutation();
+  const [_, startTransition] = useTransition();
 
   const [isEmailSent, setIsEmailSent] = useState(false);
   const [isToastOpen, setIsToastOpen] = useState(false);
@@ -82,7 +83,10 @@ const UnivEmailInputContainer = ({ openServiceAgreeBottomSheet }: UnivEmailInput
 
             const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
               field.onChange(e);
-              await trigger('univEmail');
+
+              startTransition(() => {
+                trigger('univEmail');
+              });
             };
 
             return (

--- a/src/components/ButtonInput/ButtonInput.tsx
+++ b/src/components/ButtonInput/ButtonInput.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useTransition } from 'react';
 import { Control, Controller, FieldValues, Path, useFormContext } from 'react-hook-form';
 
 import {
@@ -44,6 +44,7 @@ const ButtonInput = <T extends FieldValues>({
 }: ButtonInputProps<T>) => {
   const { trigger } = useFormContext<T>();
   const validateButtonRef = useRef<HTMLButtonElement | null>(null);
+  const [_, startTransition] = useTransition();
 
   return (
     <div className={inputContainer}>
@@ -62,7 +63,10 @@ const ButtonInput = <T extends FieldValues>({
 
           const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
             field.onChange(e);
-            await trigger(name);
+
+            startTransition(() => {
+              trigger(name);
+            });
           };
 
           const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->
closed #188 

## As-Is
<!-- 문제 상황 정의 -->
- 빠르게 입력했을 때 입력한 값이 바로 반영되지 않고 지연되는 경우가 있음

## To-Be
<!-- 변경 사항 -->
- 기존보다 입력 지연이 개선되었음

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description

### useTransition을 통한 입력 지연 개선

이전에 리액트 렌더링 최적화를 통해 스크립트 실행 속도를 개선했었습니다.
스크립트 실행 속도가 눈에 띄게 개선되어 좋았지만, CPU 쓰로틀링을 걸었을 때 입력이 지연되는 경우가 종종 발생했습니다.

문제를 분석해봤을 때  입력할 때마다 비동기로 trigger를 호출하여 유효성 검증하는 부분을 의심해볼 수 있었습니다. 이유는 trigger의 내부 동작은 정확히 모르지만 비동기를 반환하는 걸 봤을 때 무거운 동작임을 예측해볼 수 있었습니다.

따라서 useTransition을 활용하여 trigger 호출의 우선순위를 낮추고 onChange만 실행시켜 사용자의 입력이 바로 반영되도록 반응성을 개선하였습니다. 입력이라서 상황에 따라 다르게 측정되지만, 평균적으로 통계를 내봤을 때 INP는 약 10~15% 개선된 것으로 확인되었습니다. 또한 useTransition 특징으로 우선순위 스케줄링이 가능하여 빠르게 입력할수록 유효성 검증을 하다가 취소하고 입력을 우선적으로 처리합니다. 따라서 빠른 입력일수록 스크립트 실행 속도도 개선되는 효과를 볼 수 있습니다.

```tsx
const [_, startTransition] = useTransition();

...
const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
  field.onChange(e);

  startTransition(() => {
      trigger(name);
   });
};
```

### 실험 결과

이벤트 핸들러 내에서 처리되는 trigger가 다음 입력과 같은 우선순위라면 trigger가 실행될 때 입력이 들어와도 trigger의 실행을 멈추지 못합니다. 하지만 useTransition으로 trigger의 우선순위를 명시적으로 낮추면 사용자 입력이 들어올 때, 사용자 입력을 우선적으로 처리하여 입력 지연을 개선할 수 있었습니다.
입력하는 속도나 상황이 매번 달라서 성능 측정에 어려움이 있었는데 평균적인 수치로 계산했을 때 수치가 개선된 것을 확인할 수 있었습니다. input 이벤트에서 발생하는 하위의 함수 호출들이 이벤트 핸들러 내의 로직인데, 이벤트가 실행된 총 시간이 458.8ms -> 140.5ms -> 115.4ms 로 크게 감소하였습니다.

| 개선 전 | 1차 개선 | 2차 개선 |
|:-:|:-:|:-:|
|<img width="825" alt="예전_로컬_이벤트" src="https://github.com/user-attachments/assets/b5a0450a-77ca-4825-b2ec-5c165ad74bc8" />|<img width="825" alt="배포서버_event_실행속도" src="https://github.com/user-attachments/assets/4e79a03e-ebfd-4692-8bf3-480a2f9ac985" />|<img width="825" alt="로컬호스트_event_실행속도" src="https://github.com/user-attachments/assets/7409ce47-b4d3-4832-a705-2ac1869c2046" />|


실제로 flame chart를 확인하면 차이점을 확인할 수 있습니다. useTransition으로 우선순위를 낮춰 해당 콜백함수가 input 이벤트 이후에 추가적으로 발생한 것을 알 수 있습니다. 이때 입력이 빠르게 들어올 경우 trigger 함수 호출이 취소되고 사용자 입력을 우선적으로 처리합니다. 이로 인해 빠른 입력일수록 더 개선 효과가 크다는 것을 알 수 있습니다.

| useTransition 적용 전 | useTransition 적용 후 |
|:-:|:-:|
|<img width="1165" alt="useTransition 적용 전" src="https://github.com/user-attachments/assets/cbb2c0c2-dd3d-4443-952c-8cc4e6f05c77" />|<img width="825" alt="useTransition 적용 후" src="https://github.com/user-attachments/assets/8b677deb-1ca6-4d25-beaa-c121195e3840" />|




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이메일 입력 시 검증이 더 부드럽게 처리되어 입력 중 화면 응답성이 향상되었습니다.

* **버그 수정**
  * 단계 진행 로직이 더욱 견고해져, 예기치 않은 입력값에도 올바르게 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->