### PR TITLE
[YS-519] 맵핑되지 않은 지역 수정

### DIFF
--- a/src/app/home/home.constants.ts
+++ b/src/app/home/home.constants.ts
@@ -1,5 +1,6 @@
-export const REGION_MAPPER: Record<string, string> = {
-  ALL: '전국',
+import { AreaType, RegionType } from '@/types/filter';
+
+export const REGION_MAPPER: Record<RegionType, string> = {
   SEOUL: '서울',
   GYEONGGI: '경기',
   INCHEON: '인천',
@@ -17,9 +18,10 @@ export const REGION_MAPPER: Record<string, string> = {
   JEONNAM: '전남',
   JEONBUK: '전북',
   JEJU: '제주',
+  NONE: '전체',
 } as const;
 
-export const AREA_MAPPER: Record<string, string> = {
+export const AREA_MAPPER: Record<AreaType, string> = {
   // 서울 부분 (기존 항목)
   SEOUL_ALL: '전체',
   GEUMCHEONGU: '금천구',
@@ -94,7 +96,7 @@ export const AREA_MAPPER: Record<string, string> = {
   HWASEONGSI: '화성시',
 
   // 인천
-  INCHOEN_ALL: '전체',
+  INCHEON_ALL: '전체',
   GANGHWAGUN: '강화군',
   GYEYANGGU: '계양구',
   NAMDONGGU: '남동구',
@@ -316,8 +318,7 @@ export const AREA_MAPPER: Record<string, string> = {
   JEJU_SEOGWIPOSI: '제주 서귀포시',
   JEJU_JEJUSI: '제주 제주시',
 
-  // 기타
-  NONE: '없음',
+  NONE: '전체',
 } as const;
 
 export const AREA_ALL = [

--- a/src/app/home/home.utils.test.ts
+++ b/src/app/home/home.utils.test.ts
@@ -7,6 +7,8 @@ import {
   getRegionFilterText,
 } from './home.utils';
 
+import { AreaType } from '@/types/filter';
+
 describe('formatPostDate - 실험공고 날짜 형식 맞추는 유틸 함수', () => {
   it('시작일과 종료일이 모두 있는 경우 범위 형식으로 날짜 문자열을 반환한다.', () => {
     // Given
@@ -191,7 +193,7 @@ describe('getRegionFilterText - 지역 filter 텍스트 유틸 함수', () => {
   it('지역과 세부 지역 1개 있는 경우, 지역과 세부 지역을 함께 반환한다.', () => {
     // Given
     const region = 'SEOUL';
-    const areas = ['GANGNAMGU'];
+    const areas: AreaType[] = ['GANGNAMGU'];
     const expected = '서울 · 강남구';
     // When
     const result = getRegionFilterText(region, areas);
@@ -203,7 +205,7 @@ describe('getRegionFilterText - 지역 filter 텍스트 유틸 함수', () => {
   it('지역과 세부 지역 2개 이상 있는 경우, 지역과 첫 번째 세부 지역과 나머지 개수를 반환한다.', () => {
     // Given
     const region = 'SEOUL';
-    const areas = ['GANGNAMGU', 'GANGDONGGU', 'MAPOGU'];
+    const areas: AreaType[] = ['GANGNAMGU', 'GANGDONGGU', 'MAPOGU'];
     const expected = '서울 · 강남구 외 2';
     // When
     const result = getRegionFilterText(region, areas);
@@ -227,7 +229,7 @@ describe('getRegionFilterText - 지역 filter 텍스트 유틸 함수', () => {
   it('지역이 없는 경우, 기본 메시지 "지역"을 반환한다.', () => {
     // Given
     const region = undefined;
-    const areas = ['GANGNAMGU'];
+    const areas: AreaType[] = ['GANGNAMGU'];
     const expected = '지역';
 
     // When

--- a/src/app/home/home.utils.ts
+++ b/src/app/home/home.utils.ts
@@ -3,7 +3,7 @@ import { GenderFilterValue } from './home.types';
 
 import { ParticipantResponse, ResearcherResponse } from '@/apis/login';
 import { colors } from '@/styles/colors';
-import { RegionType } from '@/types/filter';
+import { AreaType, RegionType } from '@/types/filter';
 import { isParticipantInfo } from '@/utils/typeGuard';
 
 export const formatPostDate = ({
@@ -81,7 +81,7 @@ export const getContactTargetFilterText = (age?: number, gender?: GenderFilterVa
   return '모집 대상';
 };
 
-export const getRegionFilterText = (region?: RegionType | null, areas?: string[]) => {
+export const getRegionFilterText = (region?: RegionType | null, areas?: AreaType[]) => {
   const isArea = areas && areas.length > 0;
 
   if (region) {

--- a/src/app/user/profile/mobile/components/MobileProfileSection/MobileProfileSection.tsx
+++ b/src/app/user/profile/mobile/components/MobileProfileSection/MobileProfileSection.tsx
@@ -11,6 +11,7 @@ import { ParticipantResponse } from '@/apis/login';
 import { AREA_MAPPER, REGION_MAPPER } from '@/app/home/home.constants';
 import useUserInfo from '@/app/home/hooks/useUserInfo';
 import { PATH } from '@/constants/path';
+import { AreaType, RegionType } from '@/types/filter';
 import { isParticipantInfo } from '@/utils/typeGuard';
 
 const MATCH_TYPE_MAP = {
@@ -43,13 +44,14 @@ const MOBILE_PROFILE_FIELDS_MAP = {
       required: true,
       title: '거주 지역',
       getLabel: (userInfo: ParticipantResponse) => {
-        const region = REGION_MAPPER[userInfo.basicAddressInfo.region];
-        const area = AREA_MAPPER[userInfo.basicAddressInfo.area];
+        const region = REGION_MAPPER[userInfo.basicAddressInfo.region as RegionType];
+        const area = AREA_MAPPER[userInfo.basicAddressInfo.area as AreaType];
         const isAdditionalAddress = userInfo.additionalAddressInfo.region !== 'NONE';
 
         if (isAdditionalAddress) {
-          const additionalRegion = REGION_MAPPER[userInfo.additionalAddressInfo.region];
-          const additionalArea = AREA_MAPPER[userInfo.additionalAddressInfo.area];
+          const additionalRegion =
+            REGION_MAPPER[userInfo.additionalAddressInfo.region as RegionType];
+          const additionalArea = AREA_MAPPER[userInfo.additionalAddressInfo.area as AreaType];
 
           return `${region} ${area} / ${additionalRegion} ${additionalArea}`;
         }

--- a/src/constants/filters.ts
+++ b/src/constants/filters.ts
@@ -185,7 +185,7 @@ export const AREAS = [
   'CHUNGJUSI',
 
   // 부산
-  'GANGSEOGU',
+  'BUSAN_GANGSEOGU',
   'GEUMJEONGGU',
   'GIJANGGUN',
   'NAMGU',


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->
closed #199 

## As-Is
<!-- 문제 상황 정의 -->
- 부산 강서구가 맵핑되지 않아 필터링 적용이 되지 않음

## To-Be
<!-- 변경 사항 -->
- 부산 강서구 필드명 수정
- 맵핑잘되도록 타입 연동

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 일부 지역 및 구 이름의 오타를 수정하고 일관성을 개선했습니다. (예: 'INCHOEN_ALL' → 'INCHEON_ALL', 'GANGSEOGU' → 'BUSAN_GANGSEOGU')
  * "전체" 및 "없음" 관련 표기를 통일했습니다.

* **스타일**
  * 지역 및 구 선택 관련 텍스트 표기를 '전체'로 통일하여 사용자 경험을 개선했습니다.

* **테스트**
  * 테스트 코드에서 타입 명시를 강화하여 안정성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->