### PR TITLE
[YS-511] 공고 상세 QA 반영 및 작성 글 목록 스타일 수정

### DIFF
--- a/src/app/my-posts/components/MyPostsTable/MyPostsTable.css.ts
+++ b/src/app/my-posts/components/MyPostsTable/MyPostsTable.css.ts
@@ -98,3 +98,10 @@ export const emptySubTitle = style({
   color: colors.text04,
   marginBottom: '1.6rem',
 });
+
+export const titleColumn = style({
+  padding: '1rem 0',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});

--- a/src/app/my-posts/components/MyPostsTable/MyPostsTable.tsx
+++ b/src/app/my-posts/components/MyPostsTable/MyPostsTable.tsx
@@ -27,6 +27,7 @@ import {
   tableInfoRow,
   tableBody,
   tableRow,
+  titleColumn,
 } from './MyPostsTable.css';
 import { MyPosts, UseMyPostsQueryResponse } from '../../hooks/useMyPostsQuery';
 import useUpdateRecruitStatusMutation from '../../hooks/useUpdateRecruitStatusMutation';
@@ -126,9 +127,7 @@ const MyPostsTable = ({
             href={`/post/${experimentPostId}`}
             style={{ textDecoration: 'none', color: 'inherit' }}
           >
-            <div style={{ width: '100%', height: '100%', padding: '1rem 0' }}>
-              {row.getValue('title')}
-            </div>
+            <div className={titleColumn}>{row.getValue('title')}</div>
           </Link>
         );
       },

--- a/src/app/post/[postId]/desktop/components/ExperimentPostContainer/ExperimentPostContainer.tsx
+++ b/src/app/post/[postId]/desktop/components/ExperimentPostContainer/ExperimentPostContainer.tsx
@@ -30,15 +30,6 @@ const ExperimentPostContainer = () => {
     postId: normalizedPostId,
   });
 
-  if (isLoading) {
-    return (
-      <div className={emptyViewLayout}>
-        <Spinner />
-        <p className={emptySubTitle}>로딩중</p>
-      </div>
-    );
-  }
-
   if (postError || methodError) {
     return (
       <div className={emptyViewLayout}>
@@ -50,10 +41,11 @@ const ExperimentPostContainer = () => {
     );
   }
 
-  if (!postDetailData) {
+  if (isLoading || !postDetailData) {
     return (
       <div className={emptyViewLayout}>
-        <p className={emptySubTitle}>공고 상세 정보가 없습니다.</p>
+        <Spinner />
+        <p className={emptySubTitle}>로딩중</p>
       </div>
     );
   }

--- a/src/app/post/[postId]/mobile/components/ExperimentPostMobileContentContainer/ExperimentPostMobileContentContainer.tsx
+++ b/src/app/post/[postId]/mobile/components/ExperimentPostMobileContentContainer/ExperimentPostMobileContentContainer.tsx
@@ -21,6 +21,7 @@ import {
   copyToastViewport,
 } from '../ParticipationGuideBottomSheet/ParticipationGuideBottomSheet.css';
 
+import { emptySubTitle } from '@/app/my-posts/components/MyPostsTable/MyPostsTable.css';
 import Button from '@/components/Button/Button';
 import Icon from '@/components/Icon';
 import Spinner from '@/components/Spinner/Spinner';
@@ -46,14 +47,6 @@ const ExperimentPostMobileContentContainer = ({
 
   const postDetailData = experimentDetailResponse.data;
 
-  if (experimentDetailResponse.isLoading) {
-    return (
-      <div className={emptyView}>
-        <Spinner />
-      </div>
-    );
-  }
-
   if (experimentDetailResponse.error) {
     return (
       <div className={emptyView}>
@@ -65,12 +58,14 @@ const ExperimentPostMobileContentContainer = ({
     );
   }
 
-  if (!postDetailData)
+  if (experimentDetailResponse.isLoading || !postDetailData) {
     return (
       <div className={emptyView}>
-        <div className={emptyViewTitle}>공고 상세 정보가 없습니다.</div>
+        <Spinner />
+        <p className={emptySubTitle}>로딩중</p>
       </div>
     );
+  }
 
   const handleOpenBottomSheet = () => {
     open(

--- a/src/app/post/[postId]/mobile/components/ParticipationGuideBottomSheet/ParticipationGuideBottomSheet.css.ts
+++ b/src/app/post/[postId]/mobile/components/ParticipationGuideBottomSheet/ParticipationGuideBottomSheet.css.ts
@@ -27,6 +27,7 @@ export const contactInfoRowContainer = style({
 export const contactInfoTitle = style({
   ...fonts.label.large.M14,
   width: '3.7rem',
+  minWidth: 'fit-content',
   color: colors.text03,
 });
 

--- a/src/app/post/[postId]/mobile/components/ParticipationGuideBottomSheet/ParticipationGuideBottomSheet.tsx
+++ b/src/app/post/[postId]/mobile/components/ParticipationGuideBottomSheet/ParticipationGuideBottomSheet.tsx
@@ -34,10 +34,6 @@ const ParticipationGuideBottomSheet = ({
     refetch: refetchApply,
   } = useApplyMethodQuery({ postId });
 
-  if (isLoadingApply) {
-    return <Spinner height={150} />;
-  }
-
   if (errorApply) {
     return (
       <div className={emptyView}>
@@ -49,13 +45,8 @@ const ParticipationGuideBottomSheet = ({
     );
   }
 
-  if (!applyMethodData) {
-    return (
-      <div className={emptyView}>
-        <Icon icon="Alert" width={24} height={24} color={colors.textAlert} />
-        잠시 후 다시 시도해 주세요.
-      </div>
-    );
+  if (isLoadingApply || !applyMethodData) {
+    return <Spinner height={150} />;
   }
 
   const handleCopyContent = (text: string) => {

--- a/src/providers/OverlayProvider.tsx
+++ b/src/providers/OverlayProvider.tsx
@@ -1,4 +1,5 @@
-import { createContext, PropsWithChildren, useCallback, useMemo, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { createContext, PropsWithChildren, useCallback, useEffect, useMemo, useState } from 'react';
 
 import BottomSheet from '@/components/BottomSheet/BottomSheet';
 import { HeaderMode } from '@/types/bottomSheet';
@@ -30,6 +31,8 @@ export const OverlayProvider = ({ children }: PropsWithChildren) => {
     isOpen: false,
   });
 
+  const pathname = usePathname();
+
   const open = useCallback((Component: React.FC<OverlayState> | null, props?: OverlayProps) => {
     setOverlay({
       ...props,
@@ -51,6 +54,12 @@ export const OverlayProvider = ({ children }: PropsWithChildren) => {
       Component: null,
     }));
   }, []);
+
+  // 라우터 이동 또는 브라우저 뒤로가기 발생 시 바텀시트 닫음
+  useEffect(() => {
+    close();
+    exit();
+  }, [close, exit, pathname]);
 
   const dispatch = useMemo(() => ({ open, close }), [open, close]);
 


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->
close #193 

## As-Is
<!-- 문제 상황 정의 -->

- `BottomSheet`가 열린 상태로 페이지 이동을 했을 때 여전히 열려 있음
- `!postDetailData` 분기에 걸려 "공고 정보가 없습니다" 텍스트가 먼저 뜸

## To-Be
<!-- 변경 사항 -->

- `BottomSheet`가 열린 상태로 페이지 이동을 하면 `BottomSheet`를 닫음.
-  로딩 UI가 먼저 그려짐

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


### 공고 상세 로딩
| AS-IS | TO-BE |
|:--:|:--:|
| ![AS-IS](https://github.com/user-attachments/assets/f8fd68fe-d62a-45f2-b57d-7143cb58df1c) | ![TO-BE](https://github.com/user-attachments/assets/a40b10a2-2442-4cb5-a37e-f2d5b33dc601)  |


<br/>

### 바텀 시트 열린 채 페이지 이동
| AS-IS | TO-BE |
|:--:|:--:|
| ![페이지이동시바텀시트안닫힘](https://github.com/user-attachments/assets/b23233cb-d2d5-45a8-900d-2890454ec133) | ![뒤로가기시바텀시트닫기](https://github.com/user-attachments/assets/5f8b9a09-fd08-4e8c-950e-13eddde11f0d) |




## (Optional) Additional Description

- 작성글 목록에서 제목이 길어질 시 말줄임표 처리를 추가하였습니다.

- API 요청이 정상적으로 응답을 줄 땐 항상 데이터가 존재하므로  '데이터가 없을 때'의 분기는 제거하였습니다. 또한 기존 순서로는 `isLoading` 분기가 우선 실행되어 로딩 중 에러가 발생해도 erorr 분기는 검사되지 않고 끊임없이 로딩화면만 보이는 문제가 있어 에러 화면이 즉시 렌더링 될 수 있게 조건문 순서를 바꾸었습니다!

- 또한 "참여 방법 바텀시트"를 연 상태에서 페이지 이동을 해도 계속 열려있다는 QA가 있었는데 이건 참여 방법뿐만 아니라 바텀시트를 사용하는 곳에서 모두 해당되는 내용이라 `OverlayProvider`에 아래와 같은 코드를 추가하였습니다. 

```ts
// OverlayProvider.tsx

const pathname = usePathname();
  useEffect(() => {
    close();
    exit();
  }, [close, exit, pathname]);
 ```

혹시 다른 의견 있다면 말씀해주세요 ~~ ! 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 테이블 제목 셀에 CSS 스타일을 적용하여 텍스트가 길 경우 줄임표로 처리되도록 개선했습니다.
  * 모바일 상세 페이지에서 로딩 및 데이터 없음 상태를 하나의 조건문으로 통합하고, 로딩 메시지를 "로딩중"으로 변경했습니다.
  * 모바일 참여 가이드에서 로딩 및 데이터 없음 상태를 하나의 조건문으로 통합하여 사용자 경험을 개선했습니다.
  * 연락처 정보 제목의 최소 너비가 콘텐츠 크기를 유지하도록 CSS를 수정했습니다.
  * 페이지 이동 시 오버레이(바텀시트)가 자동으로 닫히도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->