### PR TITLE
[YS-545] 회원가입 코드 리팩토링 (PC)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm lint

--- a/src/app/join/JoinPage.css.ts
+++ b/src/app/join/JoinPage.css.ts
@@ -45,12 +45,6 @@ export const contentContainer = style({
   width: '100%',
 });
 
-export const titleContainer = style({
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-});
-
 export const joinContentContainer = style({
   backgroundColor: colors.field02,
   width: '100%',
@@ -59,26 +53,6 @@ export const joinContentContainer = style({
   gap: '2rem',
   borderRadius: '1.2rem',
   padding: '3.2rem 4rem',
-});
-
-export const joinTitle = style({
-  ...fonts.title.medium.SB20,
-  color: colors.text06,
-});
-
-export const progressBarContainer = style({
-  width: '8rem',
-  height: '0.6rem',
-  backgroundColor: colors.field03,
-  borderRadius: '0.6rem',
-});
-
-export const progressBarFill = style({
-  width: 'var(--progress-width)',
-  height: '100%',
-  backgroundColor: colors.primaryMint,
-  borderRadius: '0.6rem',
-  transition: 'width 1s',
 });
 
 export const joinForm = style({

--- a/src/app/join/JoinPage.types.ts
+++ b/src/app/join/JoinPage.types.ts
@@ -1,8 +1,9 @@
-// TODO: 타입 좁히기
-// birthDate: '2025-01-22';
+import { STEP } from './JoinPage.constants';
+
 // region 타입, area 타입
 export type Gender = 'MALE' | 'FEMALE' | 'ALL';
 export type MatchType = 'ONLINE' | 'OFFLINE' | 'ALL';
+export type StepType = (typeof STEP)[keyof typeof STEP];
 
 export interface ServiceAgreeCheck {
   isTermOfService: boolean;

--- a/src/app/join/components/FormGuard/FormGuard.tsx
+++ b/src/app/join/components/FormGuard/FormGuard.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useFormContext } from 'react-hook-form';
+
+import ConfirmModal from '@/components/Modal/ConfirmModal/ConfirmModal';
+import useLeaveConfirmModal from '@/hooks/useLeaveConfirmModal';
+import { colors } from '@/styles/colors';
+
+const FormGuard = ({ children }: { children: React.ReactNode }) => {
+  const { formState } = useFormContext();
+  const { isLeaveConfirmModalOpen, handleConfirmLeave, handleCancelLeave } = useLeaveConfirmModal({
+    isUserInputDirty: formState.isDirty,
+  });
+
+  return (
+    <>
+      {children}
+      <ConfirmModal
+        isOpen={isLeaveConfirmModalOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            handleCancelLeave();
+          }
+        }}
+        confirmTitle="페이지에서 나가시겠어요?"
+        descriptionText="입력한 내용은 따로 저장되지 않아요"
+        cancelText="취소"
+        confirmText="나가기"
+        confirmButtonColor={colors.field09}
+        onConfirm={() => handleConfirmLeave({ goHome: true })}
+      />
+    </>
+  );
+};
+
+export default FormGuard;

--- a/src/app/join/components/FormGuard/FormGuard.tsx
+++ b/src/app/join/components/FormGuard/FormGuard.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import { PropsWithChildren } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import ConfirmModal from '@/components/Modal/ConfirmModal/ConfirmModal';
 import useLeaveConfirmModal from '@/hooks/useLeaveConfirmModal';
 import { colors } from '@/styles/colors';
 
-const FormGuard = ({ children }: { children: React.ReactNode }) => {
+const FormGuard = ({ children }: PropsWithChildren) => {
   const { formState } = useFormContext();
   const { isLeaveConfirmModalOpen, handleConfirmLeave, handleCancelLeave } = useLeaveConfirmModal({
     isUserInputDirty: formState.isDirty,

--- a/src/app/join/components/JoinLayout/JoinLayout.tsx
+++ b/src/app/join/components/JoinLayout/JoinLayout.tsx
@@ -5,10 +5,11 @@ import FormGuard from '../FormGuard/FormGuard';
 import JoinTitleSection from '../JoinTitleSection/JoinTitleSection';
 
 import Logo from '@/components/Logo/Logo';
+import { StepType } from '../../JoinPage.types';
 
 interface JoinLayoutTitleProps {
   title: string;
-  step: string;
+  step: StepType;
 }
 
 export const JoinLayout = {

--- a/src/app/join/components/JoinLayout/JoinLayout.tsx
+++ b/src/app/join/components/JoinLayout/JoinLayout.tsx
@@ -1,0 +1,21 @@
+import { contentContainer } from '../../JoinPage.css';
+import JoinTitleSection from '../JoinTitleSection/JoinTitleSection';
+
+import Logo from '@/components/Logo/Logo';
+
+interface JoinLayoutContainerProps {
+  children: React.ReactNode;
+}
+
+interface JoinLayoutTitleProps {
+  title: string;
+  step: string;
+}
+
+export const JoinLayout = {
+  Header: () => <Logo />,
+  Container: ({ children }: JoinLayoutContainerProps) => (
+    <div className={contentContainer}>{children}</div>
+  ),
+  Title: ({ title, step }: JoinLayoutTitleProps) => <JoinTitleSection title={title} step={step} />,
+};

--- a/src/app/join/components/JoinLayout/JoinLayout.tsx
+++ b/src/app/join/components/JoinLayout/JoinLayout.tsx
@@ -1,11 +1,11 @@
 import { PropsWithChildren } from 'react';
 
 import { contentContainer } from '../../JoinPage.css';
+import { StepType } from '../../JoinPage.types';
 import FormGuard from '../FormGuard/FormGuard';
 import JoinTitleSection from '../JoinTitleSection/JoinTitleSection';
 
 import Logo from '@/components/Logo/Logo';
-import { StepType } from '../../JoinPage.types';
 
 interface JoinLayoutTitleProps {
   title: string;

--- a/src/app/join/components/JoinLayout/JoinLayout.tsx
+++ b/src/app/join/components/JoinLayout/JoinLayout.tsx
@@ -1,11 +1,10 @@
+import { PropsWithChildren } from 'react';
+
 import { contentContainer } from '../../JoinPage.css';
+import FormGuard from '../FormGuard/FormGuard';
 import JoinTitleSection from '../JoinTitleSection/JoinTitleSection';
 
 import Logo from '@/components/Logo/Logo';
-
-interface JoinLayoutContainerProps {
-  children: React.ReactNode;
-}
 
 interface JoinLayoutTitleProps {
   title: string;
@@ -14,8 +13,9 @@ interface JoinLayoutTitleProps {
 
 export const JoinLayout = {
   Header: () => <Logo />,
-  Container: ({ children }: JoinLayoutContainerProps) => (
+  Title: ({ title, step }: JoinLayoutTitleProps) => <JoinTitleSection title={title} step={step} />,
+  Container: ({ children }: PropsWithChildren) => (
     <div className={contentContainer}>{children}</div>
   ),
-  Title: ({ title, step }: JoinLayoutTitleProps) => <JoinTitleSection title={title} step={step} />,
+  FormGuard: ({ children }: PropsWithChildren) => <FormGuard>{children}</FormGuard>,
 };

--- a/src/app/join/components/JoinTitleSection/JoinTitleSection.css.ts
+++ b/src/app/join/components/JoinTitleSection/JoinTitleSection.css.ts
@@ -1,0 +1,30 @@
+import { style } from '@vanilla-extract/css';
+
+import { colors } from '@/styles/colors';
+import { fonts } from '@/styles/fonts.css';
+
+export const titleContainer = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const joinTitle = style({
+  ...fonts.title.medium.SB20,
+  color: colors.text06,
+});
+
+export const progressBarContainer = style({
+  width: '8rem',
+  height: '0.6rem',
+  backgroundColor: colors.field03,
+  borderRadius: '0.6rem',
+});
+
+export const progressBarFill = style({
+  width: 'var(--progress-width)',
+  height: '100%',
+  backgroundColor: colors.primaryMint,
+  borderRadius: '0.6rem',
+  transition: 'width 1s',
+});

--- a/src/app/join/components/JoinTitleSection/JoinTitleSection.tsx
+++ b/src/app/join/components/JoinTitleSection/JoinTitleSection.tsx
@@ -1,0 +1,32 @@
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+
+import {
+  titleContainer,
+  joinTitle,
+  progressBarContainer,
+  progressBarFill,
+} from './JoinTitleSection.css';
+import { STEP } from '../../JoinPage.constants';
+
+interface JoinTitleSectionProps {
+  title: string;
+  step: string;
+}
+
+const JoinTitleSection = ({ title, step }: JoinTitleSectionProps) => {
+  return (
+    <div className={titleContainer}>
+      <h2 className={joinTitle}>{title}</h2>
+      <div className={progressBarContainer}>
+        <div
+          className={progressBarFill}
+          style={assignInlineVars({
+            '--progress-width': step === STEP.email ? '50%' : '100%',
+          })}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default JoinTitleSection;

--- a/src/app/join/components/JoinTitleSection/JoinTitleSection.tsx
+++ b/src/app/join/components/JoinTitleSection/JoinTitleSection.tsx
@@ -7,10 +7,11 @@ import {
   progressBarFill,
 } from './JoinTitleSection.css';
 import { STEP } from '../../JoinPage.constants';
+import { StepType } from '../../JoinPage.types';
 
 interface JoinTitleSectionProps {
   title: string;
-  step: string;
+  step: StepType;
 }
 
 const JoinTitleSection = ({ title, step }: JoinTitleSectionProps) => {

--- a/src/app/join/desktop/Participant/ParticipantForm.tsx
+++ b/src/app/join/desktop/Participant/ParticipantForm.tsx
@@ -2,6 +2,7 @@ import { useSession } from 'next-auth/react';
 import { useEffect } from 'react';
 import { FormProvider } from 'react-hook-form';
 
+import { JoinLayout } from '../../components/JoinLayout/JoinLayout';
 import JoinSuccessStep from '../../components/JoinSuccessStep/JoinSuccessStep';
 import useFunnel from '../../hooks/useFunnel';
 import { useParticipantJoin } from '../../hooks/useParticipantJoin';
@@ -23,7 +24,7 @@ const ParticipantForm = ({ onDirtyChange }: ParticipantFormProps) => {
   const oauthEmail = session?.oauthEmail;
   const provider = session?.provider;
 
-  const { Funnel, Step, setStep } = useFunnel(DESKTOP_PARTICIPANT_JOIN_STEP_LIST);
+  const { Funnel, step, Step, setStep } = useFunnel(DESKTOP_PARTICIPANT_JOIN_STEP_LIST);
 
   const { participantMethods, handleSubmit } = useParticipantJoin({
     initialValues: {
@@ -45,17 +46,29 @@ const ParticipantForm = ({ onDirtyChange }: ParticipantFormProps) => {
 
   return (
     <FormProvider {...participantMethods}>
-      <Funnel>
-        <Step name={STEP.email}>
-          <Participant.EmailStep onNext={() => setStep(STEP.info)} />
-        </Step>
-        <Step name={STEP.info}>
-          <Participant.InfoStep handleSubmit={handleSubmit} />
-        </Step>
-        <Step name={STEP.success}>
-          <JoinSuccessStep />
-        </Step>
-      </Funnel>
+      <JoinLayout.FormGuard>
+        <Funnel>
+          <Step name={STEP.email}>
+            <JoinLayout.Header />
+            <JoinLayout.Container>
+              <JoinLayout.Title title="참여자 회원가입" step={step} />
+              <Participant.EmailStep onNext={() => setStep(STEP.info)} />
+            </JoinLayout.Container>
+          </Step>
+          <Step name={STEP.info}>
+            <JoinLayout.Header />
+            <JoinLayout.Container>
+              <JoinLayout.Title title="참여자 회원가입" step={step} />
+              <Participant.InfoStep handleSubmit={handleSubmit} />
+            </JoinLayout.Container>
+          </Step>
+          <Step name={STEP.success}>
+            <JoinLayout.Container>
+              <JoinSuccessStep />
+            </JoinLayout.Container>
+          </Step>
+        </Funnel>
+      </JoinLayout.FormGuard>
     </FormProvider>
   );
 };

--- a/src/app/join/desktop/Participant/ParticipantForm.tsx
+++ b/src/app/join/desktop/Participant/ParticipantForm.tsx
@@ -26,6 +26,10 @@ const ParticipantForm = ({ onDirtyChange }: ParticipantFormProps) => {
   const { Funnel, Step, setStep } = useFunnel(DESKTOP_PARTICIPANT_JOIN_STEP_LIST);
 
   const { participantMethods, handleSubmit } = useParticipantJoin({
+    initialValues: {
+      oauthEmail: oauthEmail || '',
+      provider: provider as LoginProvider,
+    },
     onSuccess: () => {
       setStep(STEP.success);
     },
@@ -38,13 +42,6 @@ const ParticipantForm = ({ onDirtyChange }: ParticipantFormProps) => {
   useEffect(() => {
     onDirtyChange?.(isUserInputDirty);
   }, [isUserInputDirty, onDirtyChange]);
-
-  useEffect(() => {
-    if (oauthEmail && provider) {
-      participantMethods.setValue('oauthEmail', oauthEmail);
-      participantMethods.setValue('provider', provider as LoginProvider);
-    }
-  }, [participantMethods, oauthEmail, provider]);
 
   return (
     <FormProvider {...participantMethods}>

--- a/src/app/join/desktop/Participant/ParticipantForm.tsx
+++ b/src/app/join/desktop/Participant/ParticipantForm.tsx
@@ -1,5 +1,4 @@
 import { useSession } from 'next-auth/react';
-import { useEffect } from 'react';
 import { FormProvider } from 'react-hook-form';
 
 import { JoinLayout } from '../../components/JoinLayout/JoinLayout';
@@ -10,21 +9,14 @@ import { DESKTOP_PARTICIPANT_JOIN_STEP_LIST, STEP } from '../../JoinPage.constan
 
 import { Participant } from '.';
 
-import { ParticipantJoinSchemaType } from '@/schema/join/ParticipantJoinSchema';
 import { LoginProvider } from '@/types/user';
 
-interface ParticipantFormProps {
-  onDirtyChange?: (dirty: boolean) => void;
-}
+const ParticipantForm = () => {
+  const { Funnel, step, Step, setStep } = useFunnel(DESKTOP_PARTICIPANT_JOIN_STEP_LIST);
 
-const AUTO_INPUT_FIELDS: (keyof ParticipantJoinSchemaType)[] = ['oauthEmail'];
-
-const ParticipantForm = ({ onDirtyChange }: ParticipantFormProps) => {
   const { data: session } = useSession();
   const oauthEmail = session?.oauthEmail;
   const provider = session?.provider;
-
-  const { Funnel, step, Step, setStep } = useFunnel(DESKTOP_PARTICIPANT_JOIN_STEP_LIST);
 
   const { participantMethods, handleSubmit } = useParticipantJoin({
     initialValues: {
@@ -35,14 +27,6 @@ const ParticipantForm = ({ onDirtyChange }: ParticipantFormProps) => {
       setStep(STEP.success);
     },
   });
-
-  const isUserInputDirty = Object.keys(participantMethods.formState.dirtyFields).some(
-    (key) => !AUTO_INPUT_FIELDS.includes(key as keyof ParticipantJoinSchemaType),
-  );
-
-  useEffect(() => {
-    onDirtyChange?.(isUserInputDirty);
-  }, [isUserInputDirty, onDirtyChange]);
 
   return (
     <FormProvider {...participantMethods}>

--- a/src/app/join/desktop/Researcher/ResearcherForm.tsx
+++ b/src/app/join/desktop/Researcher/ResearcherForm.tsx
@@ -1,7 +1,7 @@
 import { useSession } from 'next-auth/react';
-import { useEffect } from 'react';
 import { FormProvider } from 'react-hook-form';
 
+import { JoinLayout } from '../../components/JoinLayout/JoinLayout';
 import JoinSuccessStep from '../../components/JoinSuccessStep/JoinSuccessStep';
 import useFunnel from '../../hooks/useFunnel';
 import { useResearcherJoin } from '../../hooks/useResearcherJoin';
@@ -9,53 +9,50 @@ import { DESKTOP_RESEARCHER_JOIN_STEP_LIST, STEP } from '../../JoinPage.constant
 
 import { Researcher } from '.';
 
-import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
 import { LoginProvider } from '@/types/user';
 
-interface ResearcherFormProps {
-  onDirtyChange?: (dirty: boolean) => void;
-}
+const ResearcherForm = () => {
+  const { Funnel, step, Step, setStep } = useFunnel(DESKTOP_RESEARCHER_JOIN_STEP_LIST);
 
-const AUTO_INPUT_FIELDS: (keyof ResearcherJoinSchemaType)[] = ['oauthEmail'];
-
-const ResearcherForm = ({ onDirtyChange }: ResearcherFormProps) => {
   const { data: session } = useSession();
   const oauthEmail = session?.oauthEmail;
   const provider = session?.provider;
 
-  const { Funnel, Step, setStep } = useFunnel(DESKTOP_RESEARCHER_JOIN_STEP_LIST);
-
   const { researcherMethods, handleSubmit } = useResearcherJoin({
     initialValues: {
-      provider: provider as LoginProvider,
       oauthEmail: oauthEmail || '',
+      provider: provider as LoginProvider,
     },
     onSuccess: () => {
       setStep(STEP.success);
     },
   });
 
-  const isUserInputDirty = Object.keys(researcherMethods.formState.dirtyFields).some(
-    (key) => !AUTO_INPUT_FIELDS.includes(key as keyof ResearcherJoinSchemaType),
-  );
-
-  useEffect(() => {
-    onDirtyChange?.(isUserInputDirty);
-  }, [isUserInputDirty, onDirtyChange]);
-
   return (
     <FormProvider {...researcherMethods}>
-      <Funnel>
-        <Step name={STEP.email}>
-          <Researcher.EmailStep onNext={() => setStep(STEP.info)} />
-        </Step>
-        <Step name={STEP.info}>
-          <Researcher.InfoStep handleSubmit={handleSubmit} />
-        </Step>
-        <Step name={STEP.success}>
-          <JoinSuccessStep />
-        </Step>
-      </Funnel>
+      <JoinLayout.FormGuard>
+        <Funnel>
+          <Step name={STEP.email}>
+            <JoinLayout.Header />
+            <JoinLayout.Container>
+              <JoinLayout.Title title="연구자 회원가입" step={step} />
+              <Researcher.EmailStep onNext={() => setStep(STEP.info)} />
+            </JoinLayout.Container>
+          </Step>
+          <Step name={STEP.info}>
+            <JoinLayout.Header />
+            <JoinLayout.Container>
+              <JoinLayout.Title title="연구자 회원가입" step={step} />
+              <Researcher.InfoStep handleSubmit={handleSubmit} />
+            </JoinLayout.Container>
+          </Step>
+          <Step name={STEP.success}>
+            <JoinLayout.Container>
+              <JoinSuccessStep />
+            </JoinLayout.Container>
+          </Step>
+        </Funnel>
+      </JoinLayout.FormGuard>
     </FormProvider>
   );
 };

--- a/src/app/join/desktop/page.tsx
+++ b/src/app/join/desktop/page.tsx
@@ -38,6 +38,8 @@ export default function JoinPage() {
     isUserInputDirty: joinFormDirty,
   });
 
+  const isResearcher = role === ROLE.researcher;
+
   useEffect(() => {
     startRecording();
   }, []);
@@ -49,7 +51,7 @@ export default function JoinPage() {
     return (
       <section className={joinLayout}>
         <div className={contentContainer}>
-          {role === ROLE.researcher ? (
+          {isResearcher ? (
             <ResearcherForm onDirtyChange={setJoinFormDirty} />
           ) : (
             <ParticipantForm onDirtyChange={setJoinFormDirty} />
@@ -66,9 +68,7 @@ export default function JoinPage() {
       </Link>
       <div className={contentContainer}>
         <div className={titleContainer}>
-          <h2 className={joinTitle}>
-            {role === ROLE.researcher ? '연구자 회원가입' : '참여자 회원가입'}
-          </h2>
+          <h2 className={joinTitle}>{isResearcher ? '연구자 회원가입' : '참여자 회원가입'}</h2>
           <div className={progressBarContainer}>
             <div
               className={progressBarFill}
@@ -78,7 +78,7 @@ export default function JoinPage() {
             />
           </div>
         </div>
-        {role === ROLE.researcher ? (
+        {isResearcher ? (
           <ResearcherForm onDirtyChange={setJoinFormDirty} />
         ) : (
           <ParticipantForm onDirtyChange={setJoinFormDirty} />

--- a/src/app/join/desktop/page.tsx
+++ b/src/app/join/desktop/page.tsx
@@ -1,105 +1,28 @@
 'use client';
 
-import { assignInlineVars } from '@vanilla-extract/dynamic';
-import Image from 'next/image';
-import Link from 'next/link';
 import { useSession } from 'next-auth/react';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
+import { joinLayout } from '../JoinPage.css';
 import ParticipantForm from './Participant/ParticipantForm';
 import ResearcherForm from './Researcher/ResearcherForm';
-import useFunnel from '../hooks/useFunnel';
-import { DESKTOP_STEP_MAP, STEP } from '../JoinPage.constants';
-import {
-  contentContainer,
-  joinLayout,
-  joinTitle,
-  progressBarContainer,
-  progressBarFill,
-  titleContainer,
-} from '../JoinPage.css';
 
-import Logo from '@/assets/images/logo.svg';
-import ConfirmModal from '@/components/Modal/ConfirmModal/ConfirmModal';
 import { ROLE } from '@/constants/config';
-import useLeaveConfirmModal from '@/hooks/useLeaveConfirmModal';
 import { startRecording } from '@/lib/mixpanelClient';
-import { colors } from '@/styles/colors';
-import { Role } from '@/types/user';
 
 export default function JoinPage() {
   const { data: session } = useSession();
+
   const role = session?.role;
-
-  const { step } = useFunnel(DESKTOP_STEP_MAP[role as Role]);
-
-  const [joinFormDirty, setJoinFormDirty] = useState(false);
-  const { isLeaveConfirmModalOpen, handleConfirmLeave, handleCancelLeave } = useLeaveConfirmModal({
-    isUserInputDirty: joinFormDirty,
-  });
-
   const isResearcher = role === ROLE.researcher;
 
   useEffect(() => {
     startRecording();
   }, []);
 
-  // TODO: 추후 스켈레톤 처리
-  if (!role) return null;
-
-  if (step === STEP.success) {
-    return (
-      <section className={joinLayout}>
-        <div className={contentContainer}>
-          {isResearcher ? (
-            <ResearcherForm onDirtyChange={setJoinFormDirty} />
-          ) : (
-            <ParticipantForm onDirtyChange={setJoinFormDirty} />
-          )}
-        </div>
-      </section>
-    );
-  }
-
   return (
     <section className={joinLayout}>
-      <Link href="/" aria-label="홈 화면으로 이동">
-        <Image src={Logo} alt="로고" priority />
-      </Link>
-      <div className={contentContainer}>
-        <div className={titleContainer}>
-          <h2 className={joinTitle}>{isResearcher ? '연구자 회원가입' : '참여자 회원가입'}</h2>
-          <div className={progressBarContainer}>
-            <div
-              className={progressBarFill}
-              style={assignInlineVars({
-                '--progress-width': step === STEP.email ? '50%' : '100%',
-              })}
-            />
-          </div>
-        </div>
-        {isResearcher ? (
-          <ResearcherForm onDirtyChange={setJoinFormDirty} />
-        ) : (
-          <ParticipantForm onDirtyChange={setJoinFormDirty} />
-        )}
-      </div>
-
-      {/* 회원가입 중 홈 이동 시 확인 모달 */}
-      <ConfirmModal
-        isOpen={isLeaveConfirmModalOpen}
-        onOpenChange={(open) => {
-          if (!open) {
-            handleCancelLeave();
-          }
-        }}
-        confirmTitle="페이지에서 나가시겠어요?"
-        descriptionText="입력한 내용은 따로 저장되지 않아요"
-        cancelText="취소"
-        confirmText="나가기"
-        confirmButtonColor={colors.field09}
-        onConfirm={() => handleConfirmLeave({ goHome: true })}
-      />
+      {isResearcher ? <ResearcherForm /> : <ParticipantForm />}
     </section>
   );
 }

--- a/src/app/join/hooks/useFunnel.tsx
+++ b/src/app/join/hooks/useFunnel.tsx
@@ -1,5 +1,6 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ReactElement, ReactNode, useMemo } from 'react';
+
 import { StepType } from '../JoinPage.types';
 
 const DEFAULT_STEP = 'email';

--- a/src/app/join/hooks/useFunnel.tsx
+++ b/src/app/join/hooks/useFunnel.tsx
@@ -1,11 +1,12 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ReactElement, ReactNode, useMemo } from 'react';
+import { StepType } from '../JoinPage.types';
 
 const DEFAULT_STEP = 'email';
 
 type NonEmptyArray<T> = [T, ...T[]];
 
-type StepsType = Readonly<NonEmptyArray<string>>;
+type Steps = Readonly<NonEmptyArray<StepType>>;
 
 interface StepProps<T extends string = string> {
   name: T;
@@ -16,10 +17,10 @@ interface FunnelProps {
   children: Array<ReactElement<StepProps>>;
 }
 
-const useFunnel = <Steps extends StepsType>(steps: Steps) => {
+const useFunnel = <T extends Steps>(steps: T) => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const currentStep = searchParams.get('step') ?? steps?.[0] ?? DEFAULT_STEP;
+  const currentStep = (searchParams.get('step') ?? steps?.at(0) ?? DEFAULT_STEP) as T[number];
 
   const currentStepIdx = useMemo(
     () => steps?.findIndex((step) => step === currentStep) ?? 0,

--- a/src/app/join/mobile/components/JoinHeader/JoinHeader.css.ts
+++ b/src/app/join/mobile/components/JoinHeader/JoinHeader.css.ts
@@ -1,0 +1,11 @@
+import { style } from '@vanilla-extract/css';
+
+import { colors } from '@/styles/colors';
+
+export const progressBarFill = style({
+  width: 'var(--progress-width)',
+  height: '100%',
+  backgroundColor: colors.primaryMint,
+  borderRadius: '0.6rem',
+  transition: 'width 1s',
+});

--- a/src/app/join/mobile/components/JoinHeader/JoinHeader.tsx
+++ b/src/app/join/mobile/components/JoinHeader/JoinHeader.tsx
@@ -1,9 +1,9 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import React from 'react';
 
+import { progressBarFill } from './JoinHeader.css';
 import useFunnel from '../../../hooks/useFunnel';
 import { MOBILE_STEP_MAP } from '../../../JoinPage.constants';
-import { progressBarFill } from '../../../JoinPage.css';
 import { headerTitle, headerWrapper, progressBar } from '../../page.css';
 
 import Icon from '@/components/Icon';

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import Logo from '../Logo/Logo';
 import { headerLayout, image } from './Header.css';
+import Logo from '../Logo/Logo';
 import RightHeader from './RightHeader/RightHeader';
 
 const Header = () => {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,18 +1,13 @@
 'use client';
 
-import Image from 'next/image';
-import Link from 'next/link';
-
+import Logo from '../Logo/Logo';
 import { headerLayout, image } from './Header.css';
 import RightHeader from './RightHeader/RightHeader';
-import Logo from '../../assets/images/logo.svg';
 
 const Header = () => {
   return (
     <nav className={headerLayout}>
-      <Link href="/">
-        <Image src={Logo} alt="로고" className={image} width={100} height={30} priority />
-      </Link>
+      <Logo className={image} width={100} height={30} />
       <RightHeader />
     </nav>
   );

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -1,0 +1,27 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+import LogoImage from '../../assets/images/logo.svg';
+
+interface LogoProps {
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+const Logo = ({ width, height, className }: LogoProps) => {
+  return (
+    <Link href="/">
+      <Image
+        src={LogoImage}
+        alt="로고"
+        className={className}
+        width={width}
+        height={height}
+        priority
+      />
+    </Link>
+  );
+};
+
+export default Logo;


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->
closed #228 

## As-Is
<!-- 문제 상황 정의 -->
- PC 회원가입 코드가 페이지단에 복잡하게 나열되어 수정하기 어려운 구조

## To-Be
<!-- 변경 사항 -->
- 컴포넌트 분리와 합성 컴포넌트를 사용하여 조건부 렌더링 로직을 선언적으로 개선
- props 의존성 제거

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description

기존의 복잡했던 이유는 크게 조건부 렌더링, 폼 이탈 방지 모달로 2가지라고 생각했는데요! 2가지를 개선하기 위해 합성 컴포넌트와 기능성 컴포넌트 방식을 사용했어요.

### 조건부 렌더링 로직 개선 -> 합성 컴포넌트

조건부 렌더링을 페이지 레벨에서 step에 따라 분기처리하는 로직이 있었어요. 그 부분이 구조상 어색하다고 느꼈는데, Funnel의 step을 나타내는 값이 Funnel 밖에서 분기처리를 위해 사용하고 있는 구조가 어색했어요. 그래서 step을 밖으로 빼지 않고 조건부 렌더링하는 방식을 탐구했어요.

컴포넌트 분리로도 페이지단을 깔끔하게 만들고, 하위 컴포넌트를 좀더 쪼개서 그 안에 조건부 렌더링을 추가하면 좀더 개선할 수 있지만, 수정하기 어려운 구조가 되어간다고 생각했어요. 그래서 합성 컴포넌트를 도입하여 step별로 컴포넌트를 주입하였습니다. 사실 기존 컴포넌트 자체가 복잡해보이게 되었다고 느낄 수 있지만, 페이지 컴포넌트의 복잡도를 제거하고 이정도로 해결한 건 큰 성과라고 생각해요.

### 폼 이탈 방지 모달 -> 기능성 컴포넌트 + 합성

폼 이탈 방지 모달은 기존에 joinFormDirty라는 state와 useLeaveConfirmModal 훅이 필요했어요. 변경사항을 감지하기 위해 setState를 하위 컴포넌트에 내려주고 useEffect가 추가되었죠. Modal이 메인 컨텐츠가 아닌데 컴포넌트 반환값을 흐리는 걸 개선하고 싶었고, RHF의 기능을 적극적으로 활용해서 props 의존성을 제거하고 싶었어요.

그래서 기능성 컴포넌트처럼 children만 받아 모달을 렌더링하는 로직을 추상화하였고, setState 대신 formState를 사용하여 인풋 변경 여부를 효율적으로 관리했어요. 현재는 FormGuard가 JoinLayout의 하위로 들어갈 필요는 없지만, 회원가입 구조의 일부라고 생각하여 추가하였습니다.

---

## 결론

- 합성 컴포넌트를 도입하여 흩어진 조건부 렌더링 로직을 선언적으로 관리
- 합성 컴포넌트를 활용하여 필요한 부분에서 조합하여 컴포넌트 복잡도 개선
- 폼 이탈 방지 모달을 기능성 컴포넌트 구조로 변경하여 props 의존성 제거 및 입력 변경 여부를 RHF로 효율적으로 관리



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 작성 중인 가입 페이지 이탈 시 확인 모달을 표시하도록 도입했습니다.
  - 가입 타이틀과 진행률을 표시하는 통합 타이틀 섹션이 추가되었습니다.
  - 재사용 가능한 로고 컴포넌트를 도입해 헤더 로고 렌더링을 일원화했습니다.

- 리팩터
  - 가입 흐름에 공통 레이아웃을 적용해 헤더·제목·컨테이너 구성이 일관되게 정리되었습니다.
  - 데스크톱/모바일 폼 컴포넌트의 불필요한 외부 의존(더티 트래킹 등)을 제거하고 공개 시그니처를 간소화했습니다.
  - 데스크톱 가입 페이지 렌더링 로직이 단순화되었습니다.

- 스타일
  - 진행률 바 스타일을 컴포넌트 단위로 분리해 유지보수성을 개선했습니다.

- 잡무
  - 푸시 전 린트 검사 훅을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->