### PR TITLE
[YS-550] Sentry 프로덕션에서만 로깅하도록 세팅 수정

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,19 +1,18 @@
-// This file configures the initialization of Sentry for edge features (middleware, edge routes, and so on).
-// The config you add here will be used whenever one of the edge features is loaded.
-// Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
 import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+const isProductionDomain = process.env.VERCEL_ENV === 'production';
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+if (isProductionDomain) {
+  Sentry.init({
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+    tracesSampleRate: 1,
 
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+    // Enable logs to be sent to Sentry
+    enableLogs: true,
+
+    // Setting this option to true will print useful information to the console while you're setting up Sentry.
+    debug: false,
+  });
+}

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,14 +5,8 @@ const isProductionDomain = process.env.VERCEL_ENV === 'production';
 if (isProductionDomain) {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-
-    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
     tracesSampleRate: 1,
-
-    // Enable logs to be sent to Sentry
     enableLogs: true,
-
-    // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,
   });
 }

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,18 +1,18 @@
-// This file configures the initialization of Sentry on the server.
-// The config you add here will be used whenever the server handles a request.
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
 import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+const isProductionDomain = process.env.VERCEL_ENV === 'production';
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+if (isProductionDomain) {
+  Sentry.init({
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+    tracesSampleRate: 1,
 
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+    // Enable logs to be sent to Sentry
+    enableLogs: true,
+
+    // Setting this option to true will print useful information to the console while you're setting up Sentry.
+    debug: false,
+  });
+}

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,14 +5,8 @@ const isProductionDomain = process.env.VERCEL_ENV === 'production';
 if (isProductionDomain) {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-
-    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
     tracesSampleRate: 1,
-
-    // Enable logs to be sent to Sentry
     enableLogs: true,
-
-    // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,
   });
 }

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,19 +1,19 @@
-// This file configures the initialization of Sentry on the client.
-// The added config here will be used whenever a users loads a page in their browser.
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
 import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+const isProductionDomain = process.env.VERCEL_ENV === 'production';
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+if (isProductionDomain) {
+  Sentry.init({
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+    tracesSampleRate: 1,
+    // Enable logs to be sent to Sentry
+    enableLogs: true,
+
+    // Setting this option to true will print useful information to the console while you're setting up Sentry.
+    debug: false,
+  });
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -5,13 +5,8 @@ const isProductionDomain = process.env.VERCEL_ENV === 'production';
 if (isProductionDomain) {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-
-    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
     tracesSampleRate: 1,
-    // Enable logs to be sent to Sentry
     enableLogs: true,
-
-    // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,
   });
 }

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -16,7 +16,7 @@ interface LogUnhandledErrorProps {
   url: string;
 }
 
-const isProduction = process.env.NODE_ENV === 'production';
+const isProductionDomain = process.env.VERCEL_ENV === 'production';
 
 export const logAPIError = ({
   level,
@@ -25,7 +25,7 @@ export const logAPIError = ({
   url,
   errorMessage,
 }: LogAPIErrorProps) => {
-  if (!isProduction) return;
+  if (!isProductionDomain) return;
 
   Sentry.withScope((scope) => {
     scope.setLevel(level);
@@ -39,7 +39,7 @@ export const logAPIError = ({
 };
 
 export const logNetworkError = ({ url }: LogNetworkErrorProps) => {
-  if (!isProduction) return;
+  if (!isProductionDomain) return;
 
   Sentry.withScope((scope) => {
     scope.setLevel('warning');
@@ -51,7 +51,7 @@ export const logNetworkError = ({ url }: LogNetworkErrorProps) => {
 };
 
 export const logUnhandledError = ({ url }: LogUnhandledErrorProps) => {
-  if (!isProduction) return;
+  if (!isProductionDomain) return;
 
   Sentry.withScope((scope) => {
     scope.setLevel('fatal');

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -16,6 +16,8 @@ interface LogUnhandledErrorProps {
   url: string;
 }
 
+const isProduction = process.env.NODE_ENV === 'production';
+
 export const logAPIError = ({
   level,
   errorCode,
@@ -23,6 +25,8 @@ export const logAPIError = ({
   url,
   errorMessage,
 }: LogAPIErrorProps) => {
+  if (!isProduction) return;
+
   Sentry.withScope((scope) => {
     scope.setLevel(level);
     scope.setTag('api', 'apiError');
@@ -35,6 +39,8 @@ export const logAPIError = ({
 };
 
 export const logNetworkError = ({ url }: LogNetworkErrorProps) => {
+  if (!isProduction) return;
+
   Sentry.withScope((scope) => {
     scope.setLevel('warning');
     scope.setTag('api', 'networkError');
@@ -45,6 +51,8 @@ export const logNetworkError = ({ url }: LogNetworkErrorProps) => {
 };
 
 export const logUnhandledError = ({ url }: LogUnhandledErrorProps) => {
+  if (!isProduction) return;
+
   Sentry.withScope((scope) => {
     scope.setLevel('fatal');
     scope.setTag('api', 'unhandledError');

--- a/src/lib/mixpanelClient.ts
+++ b/src/lib/mixpanelClient.ts
@@ -14,7 +14,7 @@ export const initMixpanel = () => {
     return;
   }
 
-  if (!isMixpanelInitialized) {
+  if (!isMixpanelInitialized && isProductionDomain) {
     mixpanel.init(MIXPANEL_TOKEN, {
       track_pageview: false,
       persistence: 'localStorage',
@@ -49,7 +49,7 @@ export const stopRecording = () => {
  */
 
 export const trackEvent = (event: string, properties?: Record<string, any>) => {
-  if (!isClient || isTestEnv) return;
+  if (!isClient || isTestEnv || !isProductionDomain) return;
 
   if (!MIXPANEL_TOKEN) {
     console.warn('Mixpanel Token is missing.');
@@ -66,7 +66,7 @@ export const trackEvent = (event: string, properties?: Record<string, any>) => {
  * @param userId 사용자 ID
  */
 export const identifyUser = (userId: string) => {
-  if (!MIXPANEL_TOKEN || !isClient) return;
+  if (!MIXPANEL_TOKEN || !isClient || !isProductionDomain) return;
 
   try {
     mixpanel.identify(userId);
@@ -83,8 +83,7 @@ export const identifyUser = (userId: string) => {
  * @param properties 사용자 속성 데이터
  */
 export const setUserProperties = (properties: Record<string, string>) => {
-  if (!isClient) return;
-  if (!MIXPANEL_TOKEN) return;
+  if (!MIXPANEL_TOKEN || !isClient || !isProductionDomain) return;
 
   try {
     mixpanel.people.set(properties);
@@ -97,7 +96,7 @@ export const setUserProperties = (properties: Record<string, string>) => {
  * 사용자 로그아웃 (로그아웃 시 호출)
  */
 export const logoutUser = () => {
-  if (!MIXPANEL_TOKEN || !isClient) return;
+  if (!MIXPANEL_TOKEN || !isClient || !isProductionDomain) return;
 
   try {
     mixpanel.reset();

--- a/src/lib/mixpanelClient.ts
+++ b/src/lib/mixpanelClient.ts
@@ -5,7 +5,7 @@ import mixpanel from 'mixpanel-browser';
 const MIXPANEL_TOKEN = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN;
 const isClient = typeof window !== 'undefined';
 const isTestEnv = process.env.NODE_ENV === 'test';
-const isProduction = process.env.NODE_ENV === 'production';
+const isProductionDomain = process.env.VERCEL_ENV === 'production';
 let isMixpanelInitialized = false;
 
 export const initMixpanel = () => {
@@ -27,7 +27,7 @@ export const initMixpanel = () => {
 };
 
 export const startRecording = () => {
-  if (!isClient || !isProduction) {
+  if (!isClient || !isProductionDomain) {
     return;
   }
 
@@ -35,7 +35,7 @@ export const startRecording = () => {
 };
 
 export const stopRecording = () => {
-  if (!isClient || !isProduction) {
+  if (!isClient || !isProductionDomain) {
     return;
   }
 


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->
closed #233 

## As-Is
<!-- 문제 상황 정의 -->
- sentry가 localhost에서도 에러를 불필요하게 잡고 있었음 -> 노이즈가 될 수 있음

## To-Be
<!-- 변경 사항 -->
- 배포 도메인(gradmeet.co.kr)에서만 로깅하도록 처리
- sentry와 mixpanel 모두 production에서만 동작하도록 처리
   - dev.gradmeet.co.kr도 NODE_ENV가 production이므로 VERCEL_ENV로 조건 처리

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

**AS-IS**

- 기존에 sentry.init이 항상 되어서 localhost와 dev.gradmeet.co.kr에서도 요청이 가고 있었음 -> 노이즈 + 불필요한 로깅
- gradmeet.co.kr에서만 요청이 가도록 처리

<img width="775" height="238" alt="image" src="https://github.com/user-attachments/assets/9ad9b6e2-3800-4491-a659-a7b9525e081b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 비프로덕션 환경에서 오류 추적 및 로그 전송이 발생하던 문제를 해소하여 불필요한 텔레메트리 전송을 방지했습니다.
  - 분석 이벤트가 개발/미리보기 환경에서 수집되지 않도록 동작을 교정했습니다.

- 작업(Chores)
  - 모니터링 및 분석 도구 초기화를 프로덕션 환경에서만 수행하도록 조정했습니다.
  - 클라이언트 측 초기화 및 로그/추적 호출이 비프로덕션에서 건너뛰어지도록 정리하여 개인정보 보호 및 노이즈를 감소시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->