### PR TITLE
[YS-554] 공고 등록 학교 자동완성 추가

### DIFF
--- a/src/app/upload/components/InputForm/InputForm.css.ts
+++ b/src/app/upload/components/InputForm/InputForm.css.ts
@@ -21,30 +21,37 @@ export const textInputContainer = styleVariants({
   },
 });
 
-export const textInput = styleVariants({
-  default: {
+const baseInput = style({
+  ...fonts.label.large.R14,
+  width: '100%',
+  height: '4.8rem',
+  padding: '0.8rem 1.6rem',
+  border: `0.1rem solid ${colors.line01}`,
+  borderRadius: '1.2rem',
+  color: colors.text06,
+  '::placeholder': {
+    color: colors.text02,
     ...fonts.label.large.R14,
-    width: '100%',
-    height: '4.8rem',
-    padding: '0.8rem 1.6rem',
-    border: `0.1rem solid ${colors.line01}`,
-    borderRadius: '1.2rem',
-    color: colors.text06,
-    '::placeholder': {
-      color: colors.text02,
-      ...fonts.label.large.R14,
-    },
-    ':focus': {
-      borderColor: colors.lineTinted,
-      outline: 'none',
-    },
   },
+});
+
+export const textInput = styleVariants({
+  default: [
+    baseInput,
+    {
+      ':focus': {
+        borderColor: colors.lineTinted,
+        outline: 'none',
+      },
+    },
+  ],
   error: {
     border: `0.1rem solid ${colors.textAlert}`,
     ':focus': {
       borderColor: colors.textAlert,
     },
   },
+  autoInput: [baseInput],
 });
 
 export const textCounter = style({

--- a/src/app/upload/components/OutlineSection/OutlineSection.tsx
+++ b/src/app/upload/components/OutlineSection/OutlineSection.tsx
@@ -15,6 +15,7 @@ import useUserResearcherInfo from '../../hooks/useUserResearcherInfo';
 import { countSelectOptions, durationMinutesOptions } from '../../upload.constants';
 import CheckboxWithIcon from '../CheckboxWithIcon/CheckboxWithIcon';
 import InputForm from '../InputForm/InputForm';
+import { textInput } from '../InputForm/InputForm.css';
 import RadioButtonGroup from '../RadioButtonGroup/RadioButtonGroup';
 import RegionPopover from '../RegionPopover/RegionPopover';
 import SelectForm from '../SelectForm/SelectForm';
@@ -27,6 +28,7 @@ import {
 
 import { MATCH_TYPE, MatchType } from '@/app/post/[postId]/ExperimentPostPage.types';
 import DatePickerForm from '@/app/upload/components/DatePickerForm/DatePickerForm';
+import UnivAutoCompleteInput from '@/components/UnivAutoCompleteInput/UnivAutoCompleteInput';
 import { UploadExperimentPostSchemaType } from '@/schema/upload/uploadExperimentPostSchema';
 import { colors } from '@/styles/colors';
 
@@ -208,19 +210,14 @@ const OutlineSection = ({
             <div className={disabledInput}>비대면</div>
           ) : (
             <div className={uploadInputContainer}>
-              <Controller
+              <UnivAutoCompleteInput<UploadExperimentPostSchemaType>
                 name="place"
                 control={control}
-                render={({ field, fieldState }) => (
-                  <InputForm
-                    id="place"
-                    field={{ ...field }}
-                    placeholder="장소 입력"
-                    error={fieldState.error}
-                    showErrorMessage={false}
-                  />
-                )}
+                required
+                placeholder="학교명 검색"
+                inputClassName={textInput.default}
               />
+
               {/* 지역구 선택 */}
               <Controller
                 name="region"

--- a/src/app/upload/components/OutlineSection/OutlineSection.tsx
+++ b/src/app/upload/components/OutlineSection/OutlineSection.tsx
@@ -203,7 +203,7 @@ const OutlineSection = ({
 
         {/* 실험 장소 */}
         <div>
-          <label className={label} htmlFor="location">
+          <label className={label} htmlFor="place">
             실험 장소
           </label>
           {selectedMatchType === MATCH_TYPE.ONLINE ? (
@@ -215,7 +215,7 @@ const OutlineSection = ({
                 control={control}
                 required
                 placeholder="학교명 검색"
-                inputClassName={textInput.default}
+                inputClassName={textInput.autoInput}
               />
 
               {/* 지역구 선택 */}

--- a/src/app/upload/hooks/useManageExperimentPostForm.tsx
+++ b/src/app/upload/hooks/useManageExperimentPostForm.tsx
@@ -105,7 +105,7 @@ const useManageExperimentPostForm = ({
       imageListInfo: {
         images: updatedImages as string[],
       },
-      place: data.matchType === MATCH_TYPE.ONLINE ? null : data.place,
+      place: data.matchType === MATCH_TYPE.ONLINE || data.place === '' ? null : data.place,
     };
 
     if (isEdit && postId) {

--- a/src/app/upload/upload.constants.ts
+++ b/src/app/upload/upload.constants.ts
@@ -59,7 +59,7 @@ export const EXPERIMENT_POST_DEFAULT_VALUES = {
   endDate: undefined,
   matchType: undefined,
   reward: '',
-  place: undefined,
+  place: '',
   detailedAddress: '',
   region: undefined,
   area: undefined,

--- a/src/components/UnivAutoCompleteInput/UnivAutoCompleteInput.tsx
+++ b/src/components/UnivAutoCompleteInput/UnivAutoCompleteInput.tsx
@@ -18,6 +18,8 @@ interface UnivAutoCompleteInputProps<T extends FieldValues> {
   label?: string;
   required?: boolean;
   placeholder?: string;
+
+  inputClassName?: string;
 }
 
 const UnivAutoCompleteInput = <T extends FieldValues>({
@@ -26,6 +28,8 @@ const UnivAutoCompleteInput = <T extends FieldValues>({
   label,
   required,
   placeholder,
+
+  inputClassName,
 }: UnivAutoCompleteInputProps<T>) => {
   const [showDropdown, setShowDropdown] = useState(false);
 
@@ -76,13 +80,13 @@ const UnivAutoCompleteInput = <T extends FieldValues>({
                 id={name}
                 ref={inputRef}
                 placeholder={placeholder}
-                className={joinInput}
+                className={inputClassName ?? joinInput}
                 aria-invalid={fieldState.invalid ? true : false}
                 style={{ width: '100%' }}
                 onFocus={() => setShowDropdown(true)}
                 onBlur={handleBlur}
               />
-              {field.value.length > 0 ? (
+              {field.value?.length > 0 ? (
                 <button className={inputResetButton} ref={resetButtonRef} onClick={handleReset}>
                   <Icon icon="CloseRound" width={22} height={22} cursor="pointer" />
                 </button>
@@ -93,7 +97,6 @@ const UnivAutoCompleteInput = <T extends FieldValues>({
               )}
             </div>
 
-            {/* 자동완성 드롭다운 */}
             <AutoCompleteDropdown
               showDropdown={showDropdown}
               query={field.value}

--- a/src/components/UnivAutoCompleteInput/UnivAutoCompleteInput.tsx
+++ b/src/components/UnivAutoCompleteInput/UnivAutoCompleteInput.tsx
@@ -80,7 +80,7 @@ const UnivAutoCompleteInput = <T extends FieldValues>({
                 id={name}
                 ref={inputRef}
                 placeholder={placeholder}
-                className={inputClassName ?? joinInput}
+                className={`${joinInput} ${inputClassName ?? ''}`}
                 aria-invalid={fieldState.invalid ? true : false}
                 style={{ width: '100%' }}
                 onFocus={() => setShowDropdown(true)}

--- a/src/components/UnivAutoCompleteInput/components/AutoCompleteDropdown/AutoCompleteDropdown.css.ts
+++ b/src/components/UnivAutoCompleteInput/components/AutoCompleteDropdown/AutoCompleteDropdown.css.ts
@@ -42,12 +42,17 @@ export const autoCompleteDropdown = style({
   maxHeight: '25.2rem',
   padding: '0.8rem',
 
+  display: 'flex',
+  flexDirection: 'column',
   borderRadius: '1.2rem',
   border: `0.1rem solid ${colors.line02}`,
   backgroundColor: colors.field01,
   boxShadow: '0px 4px 16px rgba(53, 59, 61, 0.2)',
-  overflowY: 'auto',
   zIndex: 1,
+});
+
+export const autoCompleteList = style({
+  overflowY: 'auto',
 
   '::-webkit-scrollbar': {
     width: '2.2rem',
@@ -58,7 +63,6 @@ export const autoCompleteDropdown = style({
   '::-webkit-scrollbar-thumb': {
     backgroundColor: colors.icon02,
     borderRadius: '3rem',
-
     border: '0.8rem solid transparent',
     backgroundClip: 'padding-box',
   },
@@ -77,4 +81,23 @@ export const autoCompleteItem = style({
       backgroundColor: colors.field02,
     },
   },
+});
+
+export const autoCompleteCustomItem = style({
+  ...fonts.body.normal.M16,
+  color: colors.text06,
+  cursor: 'pointer',
+
+  height: '4.8rem',
+  padding: '1.2rem 0.8rem 0',
+  borderTop: `0.1rem solid ${colors.line01}`,
+
+  display: 'flex',
+  flexFlow: 'row nowrap',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+});
+
+export const autoCompleteHighlight = style({
+  color: colors.primaryMint,
 });

--- a/src/components/UnivAutoCompleteInput/components/AutoCompleteDropdown/AutoCompleteDropdown.tsx
+++ b/src/components/UnivAutoCompleteInput/components/AutoCompleteDropdown/AutoCompleteDropdown.tsx
@@ -52,7 +52,7 @@ const AutoCompleteDropdown = ({ showDropdown, query, onClick }: AutoCompleteDrop
                   type="button"
                   data-suggestion
                   className={autoCompleteItem}
-                  onMouseDown={() => onClick(univName)}
+                  onClick={() => onClick(univName)}
                 >
                   {parts.map((part, idx) =>
                     part.toLowerCase() === query.toLowerCase() ? (
@@ -73,7 +73,7 @@ const AutoCompleteDropdown = ({ showDropdown, query, onClick }: AutoCompleteDrop
       </ul>
 
       {query && (
-        <div data-suggestion className={autoCompleteCustomItem} onMouseDown={() => onClick(query)}>
+        <div data-suggestion className={autoCompleteCustomItem} onClick={() => onClick(query)}>
           <div>
             “<span className={autoCompleteHighlight}>{query}</span>”
             <span style={{ marginLeft: '0.8rem' }}>직접 등록하기</span>

--- a/src/components/UnivAutoCompleteInput/components/AutoCompleteDropdown/AutoCompleteDropdown.tsx
+++ b/src/components/UnivAutoCompleteInput/components/AutoCompleteDropdown/AutoCompleteDropdown.tsx
@@ -73,6 +73,7 @@ const AutoCompleteDropdown = ({ showDropdown, query, onClick }: AutoCompleteDrop
 
       {query && (
         <button
+          type="button"
           data-suggestion
           className={autoCompleteCustomItem}
           onClick={() => onClick(query)}

--- a/src/components/UnivAutoCompleteInput/components/AutoCompleteDropdown/AutoCompleteDropdown.tsx
+++ b/src/components/UnivAutoCompleteInput/components/AutoCompleteDropdown/AutoCompleteDropdown.tsx
@@ -1,12 +1,16 @@
 import {
+  autoCompleteCustomItem,
   autoCompleteDropdown,
+  autoCompleteHighlight,
   autoCompleteItem,
+  autoCompleteList,
   emptyAutoComplete,
   emptyAutoCompleteItem,
   emptyAutoCompleteText,
 } from './AutoCompleteDropdown.css';
 import { useSearchUnivNamesQuery } from '../../hooks/useSearchUnivNamesQuery';
 
+import Icon from '@/components/Icon';
 import { useDebounce } from '@/hooks/useDebounce';
 
 interface AutoCompleteDropdownProps {
@@ -22,12 +26,8 @@ const AutoCompleteDropdown = ({ showDropdown, query, onClick }: AutoCompleteDrop
   const univNames = data?.result || [];
 
   const isInitialOpen = showDropdown && univNames.length === 0 && query.length === 0;
-  const hasEmptyResult = showDropdown && univNames.length === 0 && query.length > 0;
-  const hasResult = showDropdown && univNames.length > 0;
 
-  if (!showDropdown) {
-    return null;
-  }
+  if (!showDropdown) return null;
 
   if (isInitialOpen) {
     return (
@@ -37,41 +37,51 @@ const AutoCompleteDropdown = ({ showDropdown, query, onClick }: AutoCompleteDrop
     );
   }
 
-  if (isPending || isLoading) {
-    return (
-      <div className={autoCompleteDropdown}>
-        <span className={emptyAutoCompleteItem}>검색중...</span>
-      </div>
-    );
-  }
-
-  if (hasEmptyResult) {
-    return (
-      <div className={autoCompleteDropdown}>
-        <span className={emptyAutoCompleteItem}>검색 결과가 없습니다.</span>
-      </div>
-    );
-  }
-
   return (
-    <>
-      {hasResult && (
-        <ul className={autoCompleteDropdown}>
-          {univNames.map((univName) => (
-            <li key={univName}>
-              <button
-                type="button"
-                data-suggestion
-                className={autoCompleteItem}
-                onClick={() => onClick(univName)}
-              >
-                {univName}
-              </button>
-            </li>
-          ))}
-        </ul>
+    <div className={autoCompleteDropdown}>
+      <ul className={autoCompleteList}>
+        {isPending || isLoading ? (
+          <li className={emptyAutoCompleteItem}>검색중...</li>
+        ) : univNames.length > 0 ? (
+          univNames.map((univName) => {
+            const parts = query ? univName.split(new RegExp(`(${query})`, 'gi')) : [univName];
+
+            return (
+              <li key={univName}>
+                <button
+                  type="button"
+                  data-suggestion
+                  className={autoCompleteItem}
+                  onMouseDown={() => onClick(univName)}
+                >
+                  {parts.map((part, idx) =>
+                    part.toLowerCase() === query.toLowerCase() ? (
+                      <span key={idx} className={autoCompleteHighlight}>
+                        {part}
+                      </span>
+                    ) : (
+                      part
+                    ),
+                  )}
+                </button>
+              </li>
+            );
+          })
+        ) : (
+          <div className={emptyAutoCompleteItem}>일치하는 학교명이 없어요</div>
+        )}
+      </ul>
+
+      {query && (
+        <div data-suggestion className={autoCompleteCustomItem} onMouseDown={() => onClick(query)}>
+          <div>
+            “<span className={autoCompleteHighlight}>{query}</span>”
+            <span style={{ marginLeft: '0.8rem' }}>직접 등록하기</span>
+          </div>
+          <Icon icon="Chevron" rotate={270} />
+        </div>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/UnivAutoCompleteInput/components/AutoCompleteDropdown/AutoCompleteDropdown.tsx
+++ b/src/components/UnivAutoCompleteInput/components/AutoCompleteDropdown/AutoCompleteDropdown.tsx
@@ -39,7 +39,7 @@ const AutoCompleteDropdown = ({ showDropdown, query, onClick }: AutoCompleteDrop
 
   return (
     <div className={autoCompleteDropdown}>
-      <ul className={autoCompleteList}>
+      <ul className={autoCompleteList} role="listbox" aria-label="학교 검색 결과">
         {isPending || isLoading ? (
           <li className={emptyAutoCompleteItem}>검색중...</li>
         ) : univNames.length > 0 ? (
@@ -49,7 +49,6 @@ const AutoCompleteDropdown = ({ showDropdown, query, onClick }: AutoCompleteDrop
             return (
               <li key={univName}>
                 <button
-                  type="button"
                   data-suggestion
                   className={autoCompleteItem}
                   onClick={() => onClick(univName)}
@@ -68,18 +67,23 @@ const AutoCompleteDropdown = ({ showDropdown, query, onClick }: AutoCompleteDrop
             );
           })
         ) : (
-          <div className={emptyAutoCompleteItem}>일치하는 학교명이 없어요</div>
+          <li className={emptyAutoCompleteItem}>일치하는 학교명이 없어요</li>
         )}
       </ul>
 
       {query && (
-        <div data-suggestion className={autoCompleteCustomItem} onClick={() => onClick(query)}>
+        <button
+          data-suggestion
+          className={autoCompleteCustomItem}
+          onClick={() => onClick(query)}
+          aria-label={`입력한 학교명 “${query}” 직접 등록하기`}
+        >
           <div>
             “<span className={autoCompleteHighlight}>{query}</span>”
             <span style={{ marginLeft: '0.8rem' }}>직접 등록하기</span>
           </div>
           <Icon icon="Chevron" rotate={270} />
-        </div>
+        </button>
       )}
     </div>
   );


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->

close #236 

## As-Is
<!-- 문제 상황 정의 -->

- 공고 등록 시 실험 장소가 단순 input 필드임
- 대학교 자동완성 컴포넌트에 "직접 등록하기" & "검색결과 하이라이트" 적용안됨

## To-Be
<!-- 변경 사항 -->

- 공고 등록 시 실험 장소 필드를 학교 자동완성 필드로 변경
- 학교 자동완성 컴포넌트에 "직접 등록하기" & "검색결과 하이라이트" 적용

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

**as-is**
<img width="341" height="172" alt="image" src="https://github.com/user-attachments/assets/ff3c6768-aa74-4a52-beaf-54086614054c" />

- 실험장소 필드가 단순 Input 필드

**to-be**
![공고등록학교자동완성](https://github.com/user-attachments/assets/d95f285a-4d4a-4b1e-9e22-98787fd09e7c)
- 연구자 회원가입과 동일한 학교 자동완성 필드 추가


<br/>


## (Optional) Additional Description

만들어주신 AutoCompleteDropdown 컴포넌트에 "직접 등록하기"와 "검색 결과 하이라이트"를 추가하였습니다.
시안에 나오진 않았지만 검색 결과가 많아 스크롤이 발생했을 때 "직접 등록하기"는 하위에 고정되도록 적용하였습니다.
주로 스타일 위주 수정이라 화면으로 확인해주시면 감사하겠습니다!

+ 지금 PR 올리면서 깨달은 게 있는데 교내실험 필드가 추가되면서 교내실험(boolean) 여부에 따라 form 필수 값이 달라지고 있습니다!
학교 자동완성은 교내실험이 체크됐을 때 보이는 화면인데 아직 교내실험 추가에 따른 공고 등록 / 수정 API가 수정되지 않아서
바로 production 배포는 어려울 것 같아요. API가 수정되면 교내실험 필드 추가하면서 한번에 반영할게요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 업로드 폼의 장소 입력을 대학 자동완성으로 교체하고 검색어 하이라이트 및 “직접 등록하기” 옵션을 추가했습니다.
  - 플레이스 입력의 플레이스 플레이스 플레이스 자리표시자 텍스트를 "학교명 검색"으로 변경했습니다.
- Bug Fixes
  - 입력 초기화(클리어) 동작을 안전하게 처리해 예외를 방지했습니다.
  - 온라인 선택 또는 빈 입력일 때 장소 값을 전송하지 않도록 변경해 불필요한 빈값 전송을 막았습니다.
- Style
  - 입력 필드 스타일을 재구성하고 자동완성 전용 스타일·드롭다운 레이아웃·하이라이트 스타일을 도입했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->