### PR TITLE
[YS-552] useFunnel 구조 개선 및 FunnelProvider를 통한 Single Source of Truth 유지

### DIFF
--- a/src/app/join/components/FunnelLayout/FunnelLayout.tsx
+++ b/src/app/join/components/FunnelLayout/FunnelLayout.tsx
@@ -1,0 +1,29 @@
+import { PropsWithChildren } from 'react';
+
+import useFunnel from '../../hooks/useFunnel';
+import { STEP } from '../../JoinPage.constants';
+import { JoinLayout } from '../JoinLayout/JoinLayout';
+
+interface FunnelLayoutProps {
+  title: string;
+}
+
+const FunnelLayout = ({ children, title }: PropsWithChildren<FunnelLayoutProps>) => {
+  const { step } = useFunnel();
+
+  if (step === STEP.success) {
+    return <JoinLayout.Container>{children}</JoinLayout.Container>;
+  }
+
+  return (
+    <>
+      <JoinLayout.Logo />
+      <JoinLayout.Container>
+        <JoinLayout.Header title={title} />
+        {children}
+      </JoinLayout.Container>
+    </>
+  );
+};
+
+export default FunnelLayout;

--- a/src/app/join/components/FunnelLayout/FunnelLayout.tsx
+++ b/src/app/join/components/FunnelLayout/FunnelLayout.tsx
@@ -1,8 +1,13 @@
-import { PropsWithChildren } from 'react';
+'use client';
+
+import { PropsWithChildren, useEffect } from 'react';
 
 import useFunnel from '../../hooks/useFunnel';
 import { STEP } from '../../JoinPage.constants';
+import { joinLayout } from '../../JoinPage.css';
 import { JoinLayout } from '../JoinLayout/JoinLayout';
+
+import { startRecording } from '@/lib/mixpanelClient';
 
 interface FunnelLayoutProps {
   title: string;
@@ -11,18 +16,22 @@ interface FunnelLayoutProps {
 const FunnelLayout = ({ children, title }: PropsWithChildren<FunnelLayoutProps>) => {
   const { step } = useFunnel();
 
+  useEffect(() => {
+    startRecording();
+  }, []);
+
   if (step === STEP.success) {
     return <JoinLayout.Container>{children}</JoinLayout.Container>;
   }
 
   return (
-    <>
+    <main className={joinLayout}>
       <JoinLayout.Logo />
       <JoinLayout.Container>
         <JoinLayout.Header title={title} />
         {children}
       </JoinLayout.Container>
-    </>
+    </main>
   );
 };
 

--- a/src/app/join/components/JoinLayout/JoinLayout.tsx
+++ b/src/app/join/components/JoinLayout/JoinLayout.tsx
@@ -11,8 +11,8 @@ interface JoinLayoutTitleProps {
 }
 
 export const JoinLayout = {
-  Header: () => <Logo />,
-  Title: ({ title }: JoinLayoutTitleProps) => <JoinTitleSection title={title} />,
+  Logo: () => <Logo />,
+  Header: ({ title }: JoinLayoutTitleProps) => <JoinTitleSection title={title} />,
   Container: ({ children }: PropsWithChildren) => (
     <div className={contentContainer}>{children}</div>
   ),

--- a/src/app/join/components/JoinLayout/JoinLayout.tsx
+++ b/src/app/join/components/JoinLayout/JoinLayout.tsx
@@ -1,7 +1,6 @@
 import { PropsWithChildren } from 'react';
 
 import { contentContainer } from '../../JoinPage.css';
-import { StepType } from '../../JoinPage.types';
 import FormGuard from '../FormGuard/FormGuard';
 import JoinTitleSection from '../JoinTitleSection/JoinTitleSection';
 
@@ -9,12 +8,11 @@ import Logo from '@/components/Logo/Logo';
 
 interface JoinLayoutTitleProps {
   title: string;
-  step: StepType;
 }
 
 export const JoinLayout = {
   Header: () => <Logo />,
-  Title: ({ title, step }: JoinLayoutTitleProps) => <JoinTitleSection title={title} step={step} />,
+  Title: ({ title }: JoinLayoutTitleProps) => <JoinTitleSection title={title} />,
   Container: ({ children }: PropsWithChildren) => (
     <div className={contentContainer}>{children}</div>
   ),

--- a/src/app/join/components/JoinSuccessStep/JoinSuccessStep.css.ts
+++ b/src/app/join/components/JoinSuccessStep/JoinSuccessStep.css.ts
@@ -13,7 +13,7 @@ export const joinSuccessLayout = style({
 
   '@media': {
     'screen and (max-width: 767px)': {
-      height: 'calc(100dvh - 16rem)', // JoinPage padding(8rem + 8rem)
+      height: '100%', // NOTE: 모바일 대응. desktop 좁을 때 레이아웃 깨지지만 모바일 우선 고려.
     },
   },
 });

--- a/src/app/join/components/JoinTitleSection/JoinTitleSection.tsx
+++ b/src/app/join/components/JoinTitleSection/JoinTitleSection.tsx
@@ -6,15 +6,15 @@ import {
   progressBarContainer,
   progressBarFill,
 } from './JoinTitleSection.css';
-import { STEP } from '../../JoinPage.constants';
-import { StepType } from '../../JoinPage.types';
+import useFunnel from '../../hooks/useFunnel';
 
 interface JoinTitleSectionProps {
   title: string;
-  step: StepType;
 }
 
-const JoinTitleSection = ({ title, step }: JoinTitleSectionProps) => {
+const JoinTitleSection = ({ title }: JoinTitleSectionProps) => {
+  const { progress } = useFunnel();
+
   return (
     <div className={titleContainer}>
       <h2 className={joinTitle}>{title}</h2>
@@ -22,7 +22,7 @@ const JoinTitleSection = ({ title, step }: JoinTitleSectionProps) => {
         <div
           className={progressBarFill}
           style={assignInlineVars({
-            '--progress-width': step === STEP.email ? '50%' : '100%',
+            '--progress-width': `${progress}%`,
           })}
         />
       </div>

--- a/src/app/join/desktop/Participant/ParticipantForm.tsx
+++ b/src/app/join/desktop/Participant/ParticipantForm.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useSession } from 'next-auth/react';
 import { FormProvider } from 'react-hook-form';
 

--- a/src/app/join/desktop/Participant/ParticipantForm.tsx
+++ b/src/app/join/desktop/Participant/ParticipantForm.tsx
@@ -15,14 +15,11 @@ const ParticipantForm = () => {
   const { Funnel, step, Step, setStep } = useFunnel(DESKTOP_PARTICIPANT_JOIN_STEP_LIST);
 
   const { data: session } = useSession();
-  const oauthEmail = session?.oauthEmail;
-  const provider = session?.provider;
+  const oauthEmail = session?.oauthEmail ?? '';
+  const provider = session?.provider as LoginProvider;
 
   const { participantMethods, handleSubmit } = useParticipantJoin({
-    initialValues: {
-      oauthEmail: oauthEmail || '',
-      provider: provider as LoginProvider,
-    },
+    initialValues: { oauthEmail, provider },
     onSuccess: () => {
       setStep(STEP.success);
     },

--- a/src/app/join/desktop/Participant/ParticipantForm.tsx
+++ b/src/app/join/desktop/Participant/ParticipantForm.tsx
@@ -12,7 +12,7 @@ import { Participant } from '.';
 import { LoginProvider } from '@/types/user';
 
 const ParticipantForm = () => {
-  const { Funnel, step, Step, setStep } = useFunnel(DESKTOP_PARTICIPANT_JOIN_STEP_LIST);
+  const { Funnel, Step, setStep } = useFunnel(DESKTOP_PARTICIPANT_JOIN_STEP_LIST);
 
   const { data: session } = useSession();
   const oauthEmail = session?.oauthEmail ?? '';
@@ -32,14 +32,14 @@ const ParticipantForm = () => {
           <Step name={STEP.email}>
             <JoinLayout.Header />
             <JoinLayout.Container>
-              <JoinLayout.Title title="참여자 회원가입" step={step} />
+              <JoinLayout.Title title="참여자 회원가입" />
               <Participant.EmailStep onNext={() => setStep(STEP.info)} />
             </JoinLayout.Container>
           </Step>
           <Step name={STEP.info}>
             <JoinLayout.Header />
             <JoinLayout.Container>
-              <JoinLayout.Title title="참여자 회원가입" step={step} />
+              <JoinLayout.Title title="참여자 회원가입" />
               <Participant.InfoStep handleSubmit={handleSubmit} />
             </JoinLayout.Container>
           </Step>

--- a/src/app/join/desktop/Participant/ParticipantForm.tsx
+++ b/src/app/join/desktop/Participant/ParticipantForm.tsx
@@ -1,6 +1,7 @@
 import { useSession } from 'next-auth/react';
 import { FormProvider } from 'react-hook-form';
 
+import FunnelLayout from '../../components/FunnelLayout/FunnelLayout';
 import { JoinLayout } from '../../components/JoinLayout/JoinLayout';
 import JoinSuccessStep from '../../components/JoinSuccessStep/JoinSuccessStep';
 import useFunnel from '../../hooks/useFunnel';
@@ -12,7 +13,7 @@ import { Participant } from '.';
 import { LoginProvider } from '@/types/user';
 
 const ParticipantForm = () => {
-  const { Funnel, Step, setStep } = useFunnel(DESKTOP_PARTICIPANT_JOIN_STEP_LIST);
+  const { FunnelProvider, Funnel, Step, setStep } = useFunnel(DESKTOP_PARTICIPANT_JOIN_STEP_LIST);
 
   const { data: session } = useSession();
   const oauthEmail = session?.oauthEmail ?? '';
@@ -28,27 +29,21 @@ const ParticipantForm = () => {
   return (
     <FormProvider {...participantMethods}>
       <JoinLayout.FormGuard>
-        <Funnel>
-          <Step name={STEP.email}>
-            <JoinLayout.Header />
-            <JoinLayout.Container>
-              <JoinLayout.Title title="참여자 회원가입" />
-              <Participant.EmailStep onNext={() => setStep(STEP.info)} />
-            </JoinLayout.Container>
-          </Step>
-          <Step name={STEP.info}>
-            <JoinLayout.Header />
-            <JoinLayout.Container>
-              <JoinLayout.Title title="참여자 회원가입" />
-              <Participant.InfoStep handleSubmit={handleSubmit} />
-            </JoinLayout.Container>
-          </Step>
-          <Step name={STEP.success}>
-            <JoinLayout.Container>
-              <JoinSuccessStep />
-            </JoinLayout.Container>
-          </Step>
-        </Funnel>
+        <FunnelProvider>
+          <FunnelLayout title="참여자 회원가입">
+            <Funnel>
+              <Step name={STEP.email}>
+                <Participant.EmailStep onNext={() => setStep(STEP.info)} />
+              </Step>
+              <Step name={STEP.info}>
+                <Participant.InfoStep handleSubmit={handleSubmit} />
+              </Step>
+              <Step name={STEP.success}>
+                <JoinSuccessStep />
+              </Step>
+            </Funnel>
+          </FunnelLayout>
+        </FunnelProvider>
       </JoinLayout.FormGuard>
     </FormProvider>
   );

--- a/src/app/join/desktop/Researcher/ResearcherForm.tsx
+++ b/src/app/join/desktop/Researcher/ResearcherForm.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useSession } from 'next-auth/react';
 import { FormProvider } from 'react-hook-form';
 

--- a/src/app/join/desktop/Researcher/ResearcherForm.tsx
+++ b/src/app/join/desktop/Researcher/ResearcherForm.tsx
@@ -1,6 +1,7 @@
 import { useSession } from 'next-auth/react';
 import { FormProvider } from 'react-hook-form';
 
+import FunnelLayout from '../../components/FunnelLayout/FunnelLayout';
 import { JoinLayout } from '../../components/JoinLayout/JoinLayout';
 import JoinSuccessStep from '../../components/JoinSuccessStep/JoinSuccessStep';
 import useFunnel from '../../hooks/useFunnel';
@@ -12,7 +13,7 @@ import { Researcher } from '.';
 import { LoginProvider } from '@/types/user';
 
 const ResearcherForm = () => {
-  const { Funnel, Step, setStep } = useFunnel(DESKTOP_RESEARCHER_JOIN_STEP_LIST);
+  const { FunnelProvider, Funnel, Step, setStep } = useFunnel(DESKTOP_RESEARCHER_JOIN_STEP_LIST);
 
   const { data: session } = useSession();
   const oauthEmail = session?.oauthEmail ?? '';
@@ -28,27 +29,21 @@ const ResearcherForm = () => {
   return (
     <FormProvider {...researcherMethods}>
       <JoinLayout.FormGuard>
-        <Funnel>
-          <Step name={STEP.email}>
-            <JoinLayout.Header />
-            <JoinLayout.Container>
-              <JoinLayout.Title title="연구자 회원가입" />
-              <Researcher.EmailStep onNext={() => setStep(STEP.info)} />
-            </JoinLayout.Container>
-          </Step>
-          <Step name={STEP.info}>
-            <JoinLayout.Header />
-            <JoinLayout.Container>
-              <JoinLayout.Title title="연구자 회원가입" />
-              <Researcher.InfoStep handleSubmit={handleSubmit} />
-            </JoinLayout.Container>
-          </Step>
-          <Step name={STEP.success}>
-            <JoinLayout.Container>
-              <JoinSuccessStep />
-            </JoinLayout.Container>
-          </Step>
-        </Funnel>
+        <FunnelProvider>
+          <FunnelLayout title="연구자 회원가입">
+            <Funnel>
+              <Step name={STEP.email}>
+                <Researcher.EmailStep onNext={() => setStep(STEP.info)} />
+              </Step>
+              <Step name={STEP.info}>
+                <Researcher.InfoStep handleSubmit={handleSubmit} />
+              </Step>
+              <Step name={STEP.success}>
+                <JoinSuccessStep />
+              </Step>
+            </Funnel>
+          </FunnelLayout>
+        </FunnelProvider>
       </JoinLayout.FormGuard>
     </FormProvider>
   );

--- a/src/app/join/desktop/Researcher/ResearcherForm.tsx
+++ b/src/app/join/desktop/Researcher/ResearcherForm.tsx
@@ -12,7 +12,7 @@ import { Researcher } from '.';
 import { LoginProvider } from '@/types/user';
 
 const ResearcherForm = () => {
-  const { Funnel, step, Step, setStep } = useFunnel(DESKTOP_RESEARCHER_JOIN_STEP_LIST);
+  const { Funnel, Step, setStep } = useFunnel(DESKTOP_RESEARCHER_JOIN_STEP_LIST);
 
   const { data: session } = useSession();
   const oauthEmail = session?.oauthEmail ?? '';
@@ -32,14 +32,14 @@ const ResearcherForm = () => {
           <Step name={STEP.email}>
             <JoinLayout.Header />
             <JoinLayout.Container>
-              <JoinLayout.Title title="연구자 회원가입" step={step} />
+              <JoinLayout.Title title="연구자 회원가입" />
               <Researcher.EmailStep onNext={() => setStep(STEP.info)} />
             </JoinLayout.Container>
           </Step>
           <Step name={STEP.info}>
             <JoinLayout.Header />
             <JoinLayout.Container>
-              <JoinLayout.Title title="연구자 회원가입" step={step} />
+              <JoinLayout.Title title="연구자 회원가입" />
               <Researcher.InfoStep handleSubmit={handleSubmit} />
             </JoinLayout.Container>
           </Step>

--- a/src/app/join/desktop/Researcher/ResearcherForm.tsx
+++ b/src/app/join/desktop/Researcher/ResearcherForm.tsx
@@ -15,14 +15,11 @@ const ResearcherForm = () => {
   const { Funnel, step, Step, setStep } = useFunnel(DESKTOP_RESEARCHER_JOIN_STEP_LIST);
 
   const { data: session } = useSession();
-  const oauthEmail = session?.oauthEmail;
-  const provider = session?.provider;
+  const oauthEmail = session?.oauthEmail ?? '';
+  const provider = session?.provider as LoginProvider;
 
   const { researcherMethods, handleSubmit } = useResearcherJoin({
-    initialValues: {
-      oauthEmail: oauthEmail || '',
-      provider: provider as LoginProvider,
-    },
+    initialValues: { oauthEmail, provider },
     onSuccess: () => {
       setStep(STEP.success);
     },

--- a/src/app/join/desktop/page.tsx
+++ b/src/app/join/desktop/page.tsx
@@ -1,28 +1,19 @@
-'use client';
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
 
-import { useSession } from 'next-auth/react';
-import { useEffect } from 'react';
-
-import { joinLayout } from '../JoinPage.css';
 import ParticipantForm from './Participant/ParticipantForm';
 import ResearcherForm from './Researcher/ResearcherForm';
 
 import { ROLE } from '@/constants/config';
-import { startRecording } from '@/lib/mixpanelClient';
+import { authOptions } from '@/lib/auth-utils';
 
-export default function JoinPage() {
-  const { data: session } = useSession();
-
+export default async function JoinPage() {
+  const session = await getServerSession(authOptions);
   const role = session?.role;
-  const isResearcher = role === ROLE.researcher;
 
-  useEffect(() => {
-    startRecording();
-  }, []);
+  if (!role) {
+    redirect('/login');
+  }
 
-  return (
-    <section className={joinLayout}>
-      {isResearcher ? <ResearcherForm /> : <ParticipantForm />}
-    </section>
-  );
+  return <>{role === ROLE.researcher ? <ResearcherForm /> : <ParticipantForm />}</>;
 }

--- a/src/app/join/hooks/useFunnel.tsx
+++ b/src/app/join/hooks/useFunnel.tsx
@@ -43,6 +43,18 @@ interface FunnelState<T extends Steps = Steps> {
  */
 const FunnelContext = createContext<FunnelState | null>(null);
 
+/**
+ * @param steps - Funnel 컴포넌트 외부에서 선언할 땐 필수고, Funnel 컴포넌트 내부에서 선언할 땐 optional. Funnel 컴포넌트 내부에서는 외부에서 선언한 Funnel step을 따름.
+ * @returns FunnelProvider: useFunnel 반환값을 context로 전달
+ * @returns Funnel: currentStep과 Funnel의 children으로 있는 Step 컴포넌트를 맵핑하는 컴포넌트
+ * @returns Step: name을 props로 받아 자식 컴포넌트를 렌더링하는 wrapper 컴포넌트
+ * @returns setStep: currentStep 설정하는 함수
+ * @returns goToPrev: 이전 step으로 이동하는 함수
+ * @returns goToNext: 다음 step으로 이동하는 함수
+ * @returns step: currentStep
+ * @returns steps: 모든 step 배열
+ * @returns currentStepIdx: 현재 단계 idx
+ */
 const useFunnel = <T extends Steps>(steps?: T): UseFunnelReturn<T> => {
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/src/app/join/hooks/useFunnel.tsx
+++ b/src/app/join/hooks/useFunnel.tsx
@@ -61,7 +61,7 @@ const useFunnel = <T extends Steps>(steps: T) => {
   }, [currentStep]);
 
   const Step = useMemo(() => {
-    const StepComponent = (props: StepProps<Steps[number]>) => {
+    const StepComponent = (props: StepProps<T[number]>) => {
       return <>{props.children}</>;
     };
 

--- a/src/app/join/hooks/useFunnel.tsx
+++ b/src/app/join/hooks/useFunnel.tsx
@@ -1,10 +1,13 @@
 import { useRouter, useSearchParams } from 'next/navigation';
-import { ReactElement, ReactNode, useMemo } from 'react';
+import { createContext, ReactElement, ReactNode, useContext, useMemo, useCallback } from 'react';
 
 import { StepType } from '../JoinPage.types';
 
 const DEFAULT_STEP = 'email';
 
+/**
+ * Types & Interfaces
+ */
 type NonEmptyArray<T> = [T, ...T[]];
 
 type Steps = Readonly<NonEmptyArray<StepType>>;
@@ -18,47 +21,94 @@ interface FunnelProps {
   children: Array<ReactElement<StepProps>>;
 }
 
-const useFunnel = <T extends Steps>(steps: T) => {
+interface UseFunnelReturn<T extends Steps> extends FunnelState<T> {
+  Funnel: ({ children }: FunnelProps) => JSX.Element;
+  Step: (props: StepProps<T[number]>) => JSX.Element;
+}
+
+interface FunnelState<T extends Steps = Steps> {
+  step: T[number];
+  steps: T;
+  currentStepIdx: number;
+  totalSteps: number;
+  progress: number;
+  setStep: (step: T[number]) => void;
+  goToPrev: () => void;
+  goToNext: () => void;
+}
+
+/**
+ * Context
+ */
+const FunnelContext = createContext<FunnelState | null>(null);
+
+/**
+ * Hook
+ */
+const useFunnel = <T extends Steps>(steps?: T): UseFunnelReturn<T> => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const currentStep = (searchParams.get('step') ?? steps?.at(0) ?? DEFAULT_STEP) as T[number];
+
+  // 현재 단계(step) 정보 가져오기
+  const funnelContextValue = useContext(FunnelContext);
+  const funnelContextSteps = funnelContextValue?.steps;
+  const targetSteps = (steps ?? funnelContextSteps) as T;
+  const currentStep = (searchParams.get('step') ?? targetSteps?.at(0) ?? DEFAULT_STEP) as T[number];
 
   const currentStepIdx = useMemo(
-    () => steps?.findIndex((step) => step === currentStep) ?? 0,
-    [steps, currentStep],
+    () => targetSteps?.findIndex((step) => step === currentStep) ?? 0,
+    [targetSteps, currentStep],
   );
 
-  const isLast = currentStepIdx === (Array.isArray(steps) ? steps.length - 1 : 0);
+  const totalSteps = targetSteps?.length ?? 0;
+  const progress = totalSteps > 0 ? Math.round(((currentStepIdx + 1) / (totalSteps - 1)) * 100) : 0;
+  const isLast = currentStepIdx === (Array.isArray(targetSteps) ? targetSteps.length - 1 : 0);
 
-  const setStep = (step: Steps[number]) => {
-    router.push(`?step=${step}`);
-  };
+  const setStep = useCallback(
+    (step: Steps[number]) => {
+      router.push(`?step=${step}`);
+    },
+    [router],
+  );
 
-  const goToPrev = () => {
+  const goToPrev = useCallback(() => {
     if (currentStepIdx === 0) {
       router.replace('/login');
       return;
     }
 
-    setStep(steps[currentStepIdx - 1]);
-  };
-
-  const goToNext = () => {
-    if (!isLast) {
-      setStep(steps[currentStepIdx + 1]);
+    if (targetSteps) {
+      setStep(targetSteps[currentStepIdx - 1]);
     }
-  };
+  }, [currentStepIdx, targetSteps, router, setStep]);
+
+  const goToNext = useCallback(() => {
+    if (!isLast && targetSteps) {
+      setStep(targetSteps[currentStepIdx + 1]);
+    }
+  }, [isLast, targetSteps, currentStepIdx, setStep]);
 
   const Funnel = useMemo(() => {
     const FunnelComponent = ({ children }: FunnelProps) => {
       const targetStep = children.find((childStep) => childStep.props.name === currentStep);
 
-      return <>{targetStep}</>;
+      const contextValue = {
+        step: currentStep,
+        steps: targetSteps,
+        currentStepIdx,
+        totalSteps,
+        progress,
+        setStep,
+        goToPrev,
+        goToNext,
+      };
+
+      return <FunnelContext.Provider value={contextValue}>{targetStep}</FunnelContext.Provider>;
     };
 
     FunnelComponent.displayName = 'Funnel';
     return FunnelComponent;
-  }, [currentStep]);
+  }, [currentStep, targetSteps, currentStepIdx, totalSteps, progress, setStep, goToPrev, goToNext]);
 
   const Step = useMemo(() => {
     const StepComponent = (props: StepProps<T[number]>) => {
@@ -74,8 +124,10 @@ const useFunnel = <T extends Steps>(steps: T) => {
     Step,
     setStep,
     step: currentStep,
-    steps,
+    steps: targetSteps,
     currentStepIdx,
+    totalSteps,
+    progress,
     goToPrev,
     goToNext,
   } as const;

--- a/src/app/join/hooks/useFunnel.tsx
+++ b/src/app/join/hooks/useFunnel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createContext, ReactElement, ReactNode, useContext, useMemo, useCallback } from 'react';
 

--- a/src/app/join/hooks/useResearcherJoin.ts
+++ b/src/app/join/hooks/useResearcherJoin.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 

--- a/src/app/join/mobile/Participant/JoinAdditionalInfoStep/JoinAdditionalInfoStep.tsx
+++ b/src/app/join/mobile/Participant/JoinAdditionalInfoStep/JoinAdditionalInfoStep.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 

--- a/src/app/join/mobile/Participant/ParticipantForm.tsx
+++ b/src/app/join/mobile/Participant/ParticipantForm.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useSession } from 'next-auth/react';
 import { FormProvider } from 'react-hook-form';
 

--- a/src/app/join/mobile/Participant/ParticipantForm.tsx
+++ b/src/app/join/mobile/Participant/ParticipantForm.tsx
@@ -12,16 +12,13 @@ import { LoginProvider } from '@/types/user';
 
 const ParticipantForm = () => {
   const { data: session } = useSession();
-  const provider = session?.provider;
-  const oauthEmail = session?.oauthEmail;
+  const oauthEmail = session?.oauthEmail ?? '';
+  const provider = session?.provider as LoginProvider;
 
   const { Funnel, Step, setStep, goToNext } = useFunnel(MOBILE_PARTICIPANT_JOIN_STEP_LIST);
 
   const { participantMethods, handleSubmit } = useParticipantJoin({
-    initialValues: {
-      provider: provider as LoginProvider,
-      oauthEmail: oauthEmail || '',
-    },
+    initialValues: { oauthEmail, provider },
     onSuccess: () => {
       setStep(STEP.success);
     },

--- a/src/app/join/mobile/Participant/ParticipantForm.tsx
+++ b/src/app/join/mobile/Participant/ParticipantForm.tsx
@@ -5,6 +5,7 @@ import JoinSuccessStep from '../../components/JoinSuccessStep/JoinSuccessStep';
 import useFunnel from '../../hooks/useFunnel';
 import { useParticipantJoin } from '../../hooks/useParticipantJoin';
 import { MOBILE_PARTICIPANT_JOIN_STEP_LIST, STEP } from '../../JoinPage.constants';
+import MobileFunnelLayout from '../components/MobileFunnelLayout/MobileFunnelLayout';
 
 import { Participant } from '.';
 
@@ -15,7 +16,9 @@ const ParticipantForm = () => {
   const oauthEmail = session?.oauthEmail ?? '';
   const provider = session?.provider as LoginProvider;
 
-  const { Funnel, Step, setStep, goToNext } = useFunnel(MOBILE_PARTICIPANT_JOIN_STEP_LIST);
+  const { FunnelProvider, Funnel, Step, setStep, goToNext } = useFunnel(
+    MOBILE_PARTICIPANT_JOIN_STEP_LIST,
+  );
 
   const { participantMethods, handleSubmit } = useParticipantJoin({
     initialValues: { oauthEmail, provider },
@@ -26,24 +29,28 @@ const ParticipantForm = () => {
 
   return (
     <FormProvider {...participantMethods}>
-      <Funnel>
-        <Step name={STEP.contactEmail}>
-          <Participant.ContactEmailStep
-            provider={provider}
-            oauthEmail={oauthEmail}
-            onNext={goToNext}
-          />
-        </Step>
-        <Step name={STEP.info}>
-          <Participant.JoinInfoStep onNext={goToNext} />
-        </Step>
-        <Step name={STEP.additionalInfo}>
-          <Participant.JoinAdditionalInfoStep onSubmit={handleSubmit} />
-        </Step>
-        <Step name={STEP.success}>
-          <JoinSuccessStep />
-        </Step>
-      </Funnel>
+      <FunnelProvider>
+        <MobileFunnelLayout title="참여자 회원가입">
+          <Funnel>
+            <Step name={STEP.contactEmail}>
+              <Participant.ContactEmailStep
+                provider={provider}
+                oauthEmail={oauthEmail}
+                onNext={goToNext}
+              />
+            </Step>
+            <Step name={STEP.info}>
+              <Participant.JoinInfoStep onNext={goToNext} />
+            </Step>
+            <Step name={STEP.additionalInfo}>
+              <Participant.JoinAdditionalInfoStep onSubmit={handleSubmit} />
+            </Step>
+            <Step name={STEP.success}>
+              <JoinSuccessStep />
+            </Step>
+          </Funnel>
+        </MobileFunnelLayout>
+      </FunnelProvider>
     </FormProvider>
   );
 };

--- a/src/app/join/mobile/Researcher/ResearcherForm.tsx
+++ b/src/app/join/mobile/Researcher/ResearcherForm.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useSession } from 'next-auth/react';
 import { FormProvider } from 'react-hook-form';
 

--- a/src/app/join/mobile/Researcher/ResearcherForm.tsx
+++ b/src/app/join/mobile/Researcher/ResearcherForm.tsx
@@ -12,16 +12,13 @@ import { LoginProvider } from '@/types/user';
 
 const ResearcherForm = () => {
   const { data: session } = useSession();
-  const provider = session?.provider;
-  const oauthEmail = session?.oauthEmail;
+  const oauthEmail = session?.oauthEmail ?? '';
+  const provider = session?.provider as LoginProvider;
 
   const { Funnel, Step, setStep, goToNext } = useFunnel(MOBILE_RESEARCHER_JOIN_STEP_LIST);
 
   const { researcherMethods, handleSubmit } = useResearcherJoin({
-    initialValues: {
-      provider: provider as LoginProvider,
-      oauthEmail: oauthEmail || '',
-    },
+    initialValues: { oauthEmail, provider },
     onSuccess: () => {
       setStep(STEP.success);
     },

--- a/src/app/join/mobile/Researcher/ResearcherForm.tsx
+++ b/src/app/join/mobile/Researcher/ResearcherForm.tsx
@@ -5,6 +5,7 @@ import JoinSuccessStep from '../../components/JoinSuccessStep/JoinSuccessStep';
 import useFunnel from '../../hooks/useFunnel';
 import { useResearcherJoin } from '../../hooks/useResearcherJoin';
 import { MOBILE_RESEARCHER_JOIN_STEP_LIST, STEP } from '../../JoinPage.constants';
+import MobileFunnelLayout from '../components/MobileFunnelLayout/MobileFunnelLayout';
 
 import { Researcher } from '.';
 
@@ -15,7 +16,9 @@ const ResearcherForm = () => {
   const oauthEmail = session?.oauthEmail ?? '';
   const provider = session?.provider as LoginProvider;
 
-  const { Funnel, Step, setStep, goToNext } = useFunnel(MOBILE_RESEARCHER_JOIN_STEP_LIST);
+  const { FunnelProvider, Funnel, Step, setStep, goToNext } = useFunnel(
+    MOBILE_RESEARCHER_JOIN_STEP_LIST,
+  );
 
   const { researcherMethods, handleSubmit } = useResearcherJoin({
     initialValues: { oauthEmail, provider },
@@ -26,24 +29,28 @@ const ResearcherForm = () => {
 
   return (
     <FormProvider {...researcherMethods}>
-      <Funnel>
-        <Step name={STEP.contactEmail}>
-          <Researcher.ContactEmailStep
-            provider={provider}
-            oauthEmail={oauthEmail}
-            onNext={goToNext}
-          />
-        </Step>
-        <Step name={STEP.univEmail}>
-          <Researcher.UnivEmailStep onNext={goToNext} />
-        </Step>
-        <Step name={STEP.info}>
-          <Researcher.JoinInfoStep onSubmit={handleSubmit} />
-        </Step>
-        <Step name={STEP.success}>
-          <JoinSuccessStep />
-        </Step>
-      </Funnel>
+      <FunnelProvider>
+        <MobileFunnelLayout title="연구자 회원가입">
+          <Funnel>
+            <Step name={STEP.contactEmail}>
+              <Researcher.ContactEmailStep
+                provider={provider}
+                oauthEmail={oauthEmail}
+                onNext={goToNext}
+              />
+            </Step>
+            <Step name={STEP.univEmail}>
+              <Researcher.UnivEmailStep onNext={goToNext} />
+            </Step>
+            <Step name={STEP.info}>
+              <Researcher.JoinInfoStep onSubmit={handleSubmit} />
+            </Step>
+            <Step name={STEP.success}>
+              <JoinSuccessStep />
+            </Step>
+          </Funnel>
+        </MobileFunnelLayout>
+      </FunnelProvider>
     </FormProvider>
   );
 };

--- a/src/app/join/mobile/Researcher/UnivEmailInputContainer/UnivEmailInputContainer.tsx
+++ b/src/app/join/mobile/Researcher/UnivEmailInputContainer/UnivEmailInputContainer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState, useTransition } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 

--- a/src/app/join/mobile/components/JoinHeader/JoinHeader.tsx
+++ b/src/app/join/mobile/components/JoinHeader/JoinHeader.tsx
@@ -2,44 +2,31 @@ import { assignInlineVars } from '@vanilla-extract/dynamic';
 import React from 'react';
 
 import { progressBarFill } from './JoinHeader.css';
-import useFunnel from '../../../hooks/useFunnel';
-import { MOBILE_STEP_MAP } from '../../../JoinPage.constants';
 import { headerTitle, headerWrapper, progressBar } from '../../page.css';
 
+import useFunnel from '@/app/join/hooks/useFunnel';
 import Icon from '@/components/Icon';
-import { ROLE } from '@/constants/config';
 import { colors } from '@/styles/colors';
-import { Role } from '@/types/user';
 
-const headerTitleMap = {
-  [ROLE.researcher]: '연구자 회원가입',
-  [ROLE.participant]: '참여자 회원가입',
-} as const;
+interface JoinHeaderProps {
+  title: string;
+}
 
-const JoinHeader = ({ role }: { role?: Role }) => {
-  const { steps, currentStepIdx, goToPrev } = useFunnel(MOBILE_STEP_MAP[role as Role]);
-
-  const progressPercentage =
-    currentStepIdx + 1 === steps.length
-      ? '100%'
-      : `${((currentStepIdx + 1) / (steps.length - 1)) * 100}%`;
-
-  if (!role) {
-    return null;
-  }
+const JoinHeader = ({ title }: JoinHeaderProps) => {
+  const { progress, goToPrev } = useFunnel();
 
   return (
     <>
       <header className={headerWrapper}>
         <Icon icon="Arrow" width={24} height={24} color={colors.text06} onClick={goToPrev} />
-        <h1 className={headerTitle}>{headerTitleMap[role]}</h1>
+        <h1 className={headerTitle}>{title}</h1>
       </header>
 
       {/* 프로그래스 바 */}
       <div className={progressBar}>
         <div
           className={progressBarFill}
-          style={assignInlineVars({ '--progress-width': progressPercentage })}
+          style={assignInlineVars({ '--progress-width': `${progress}%` })}
         />
       </div>
     </>

--- a/src/app/join/mobile/components/MobileFunnelLayout/MobileFunnelLayout.tsx
+++ b/src/app/join/mobile/components/MobileFunnelLayout/MobileFunnelLayout.tsx
@@ -1,0 +1,27 @@
+import { PropsWithChildren } from 'react';
+
+import JoinHeader from '../JoinHeader/JoinHeader';
+
+import useFunnel from '@/app/join/hooks/useFunnel';
+import { STEP } from '@/app/join/JoinPage.constants';
+
+interface MobileFunnelLayoutProps {
+  title: string;
+}
+
+const MobileFunnelLayout = ({ children, title }: PropsWithChildren<MobileFunnelLayoutProps>) => {
+  const { step } = useFunnel();
+
+  if (step === STEP.success) {
+    return <>{children}</>;
+  }
+
+  return (
+    <>
+      <JoinHeader title={title} />
+      {children}
+    </>
+  );
+};
+
+export default MobileFunnelLayout;

--- a/src/app/join/mobile/components/MobileFunnelLayout/MobileFunnelLayout.tsx
+++ b/src/app/join/mobile/components/MobileFunnelLayout/MobileFunnelLayout.tsx
@@ -1,9 +1,12 @@
-import { PropsWithChildren } from 'react';
+'use client';
+
+import { PropsWithChildren, useEffect } from 'react';
 
 import JoinHeader from '../JoinHeader/JoinHeader';
 
 import useFunnel from '@/app/join/hooks/useFunnel';
 import { STEP } from '@/app/join/JoinPage.constants';
+import { startRecording } from '@/lib/mixpanelClient';
 
 interface MobileFunnelLayoutProps {
   title: string;
@@ -11,6 +14,10 @@ interface MobileFunnelLayoutProps {
 
 const MobileFunnelLayout = ({ children, title }: PropsWithChildren<MobileFunnelLayoutProps>) => {
   const { step } = useFunnel();
+
+  useEffect(() => {
+    startRecording();
+  }, []);
 
   if (step === STEP.success) {
     return <>{children}</>;

--- a/src/app/join/mobile/page.tsx
+++ b/src/app/join/mobile/page.tsx
@@ -1,21 +1,19 @@
-'use client';
-
-import { useSession } from 'next-auth/react';
-import { useEffect } from 'react';
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
 
 import ParticipantForm from './Participant/ParticipantForm';
 import ResearcherForm from './Researcher/ResearcherForm';
 
 import { ROLE } from '@/constants/config';
-import { startRecording } from '@/lib/mixpanelClient';
+import { authOptions } from '@/lib/auth-utils';
 
-export default function MobileJoinPage() {
-  const { data: session } = useSession();
+export default async function MobileJoinPage() {
+  const session = await getServerSession(authOptions);
   const role = session?.role;
 
-  useEffect(() => {
-    startRecording();
-  }, []);
+  if (!role) {
+    redirect('/login');
+  }
 
   return <>{role === ROLE.researcher ? <ResearcherForm /> : <ParticipantForm />}</>;
 }

--- a/src/app/join/mobile/page.tsx
+++ b/src/app/join/mobile/page.tsx
@@ -3,34 +3,19 @@
 import { useSession } from 'next-auth/react';
 import { useEffect } from 'react';
 
-import JoinHeader from './components/JoinHeader/JoinHeader';
 import ParticipantForm from './Participant/ParticipantForm';
 import ResearcherForm from './Researcher/ResearcherForm';
-import useFunnel from '../hooks/useFunnel';
-import { MOBILE_STEP_MAP, STEP } from '../JoinPage.constants';
 
 import { ROLE } from '@/constants/config';
 import { startRecording } from '@/lib/mixpanelClient';
-import { Role } from '@/types/user';
 
 export default function MobileJoinPage() {
   const { data: session } = useSession();
   const role = session?.role;
 
-  const { step } = useFunnel(MOBILE_STEP_MAP[role as Role]);
-
   useEffect(() => {
     startRecording();
   }, []);
 
-  if (step === STEP.success) {
-    return role === ROLE.researcher ? <ResearcherForm /> : <ParticipantForm />;
-  }
-
-  return (
-    <>
-      <JoinHeader role={role} />
-      {role === ROLE.researcher ? <ResearcherForm /> : <ParticipantForm />}
-    </>
-  );
+  return <>{role === ROLE.researcher ? <ResearcherForm /> : <ParticipantForm />}</>;
 }

--- a/src/components/ButtonInput/ButtonInput.tsx
+++ b/src/components/ButtonInput/ButtonInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useRef, useTransition } from 'react';
 import { Control, Controller, FieldValues, Path, useFormContext } from 'react-hook-form';
 

--- a/src/providers/OverlayProvider.tsx
+++ b/src/providers/OverlayProvider.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { usePathname } from 'next/navigation';
 import { createContext, PropsWithChildren, useCallback, useEffect, useMemo, useState } from 'react';
 

--- a/src/providers/ToastProvider.tsx
+++ b/src/providers/ToastProvider.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { createContext, PropsWithChildren, useCallback, useMemo, useState } from 'react';
 
 import Toasts from '@/components/Toast/Toasts';


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->
closed #235 

## As-Is
<!-- 문제 상황 정의 -->
- step 하위에서 Funnel 관련 정보가 필요할 때 동일한 step을 주입해야 그 값을 가져올 수 있었음
  - 동일한 값이지만, 다른 곳에서 가져온 값이라고 생각하여 어색하다고 느낌 
  - 데이터 불일치가 일어날 수 있음
- 프로그래스바 애니메이션이 동작하지 않고 있었음
  - JoinLayout.Title이 다른 컴포넌트가 생성되면서 다른 컴포넌트 인스턴스 렌더링 
- 모바일 회원가입 헤더는 따로 구현되어 있었음

## To-Be
<!-- 변경 사항 -->
- FunnelLayout으로 합치고, FunnelProvider 참조 고정으로 프로그래스바 애니메이션 재적용
  - useFunnel의 steps를 넘기면 steps를 따르고, 안넘겼을 때 Provider 하위에 있으면 상위에서 정의된 context값을 가져옴 
- 모바일 회원가입 헤더 적용
- 회원가입 완료 시 높이 깨지는 오류 수정
  - 레이아웃상, 데스크탑을 좁히는 것과 모바일에서 깨지는 것 중에 택해야되는데, 모바일에서 깨지는 것을 막기 위해 높이 수정

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description
