### PR TITLE
[YS-557] 회원가입 중 이탈 시 서버 세션이 남아 페이지가 노출되지 않는 오류 해결

### DIFF
--- a/src/app/home/hooks/useUserInfo.ts
+++ b/src/app/home/hooks/useUserInfo.ts
@@ -6,14 +6,15 @@ import useParticipantInfoQuery from './useParticipantInfoQuery';
 import useResearcherInfoQuery from './useResearcherInfoQuery';
 
 import { ROLE } from '@/constants/config';
+import { isUnauthorizedUser } from '@/lib/auth-utils';
 
 const useUserInfo = () => {
   const { data: session, status } = useSession();
 
   const role = session?.role;
   const isSessionReady = status !== 'loading';
-  const isParticipant = isSessionReady && role === ROLE.participant;
-  const isResearcher = isSessionReady && role === ROLE.researcher;
+  const isParticipant = isSessionReady && !isUnauthorizedUser(session) && role === ROLE.participant;
+  const isResearcher = isSessionReady && !isUnauthorizedUser(session) && role === ROLE.researcher;
 
   const participantQuery = useParticipantInfoQuery({ enabled: isParticipant });
   const researcherQuery = useResearcherInfoQuery({ enabled: isResearcher });

--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -1,4 +1,4 @@
-import { NextAuthOptions } from 'next-auth';
+import type { NextAuthOptions, Session } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import { signIn, signOut } from 'next-auth/react';
 
@@ -50,6 +50,10 @@ export const joinWithCredentials = async ({
 // 로그아웃 처리 함수
 export const logout = async () => {
   await signOut({ callbackUrl: '/' });
+};
+
+export const isUnauthorizedUser = (session: Session | null) => {
+  return Boolean(session?.isTempUser) && session?.accessToken === 'temp-token';
 };
 
 export const authOptions: NextAuthOptions = {

--- a/src/providers/Providers.tsx
+++ b/src/providers/Providers.tsx
@@ -35,9 +35,7 @@ export default function Providers({
       <MSWProvider>
         <CustomQueryClientProvider session={session}>
           <ToastProvider>
-          <OverlayProvider>
-            {children}
-          </OverlayProvider>
+            <OverlayProvider>{children}</OverlayProvider>
           </ToastProvider>
         </CustomQueryClientProvider>
       </MSWProvider>


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->
closed #240 

## As-Is
<!-- 문제 상황 정의 -->
- 회원가입 중 이탈 시 session.role 정보가 이전 세션을 참조하여 401을 뱉고 production SSR에선 페이지가 다운됨
- 회원가입 중 이탈 시 session.role이 남아있어 클라이언트에서 불필요한 401에러가 발생함

## To-Be
<!-- 변경 사항 -->
- API 호출 시 인증되지 않은 세션 정보 분기처리 추가
- 인증되지 않은 유저일 경우 세션 정보 초기화

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description

### sentry로 Error 추적

sentry와 discord를 연동해놨는데 어느날 production에서 GET 요청에 에러가 발생했다는 알림이 떴어요. 홈화면에서 유저 정보를 요청할 때 발생하는 에러인데 처음에는 이해하기 어려웠어요. SSR 도입 후 여러번 테스트해봤을 때도 문제가 없었고 처음 노출된 문제였어요.

<img width="984" height="282" alt="image" src="https://github.com/user-attachments/assets/2b217dbd-b575-448d-9876-a7897b738d00" />

확인해보니 회원가입 중 이탈한 유저였고, 해당 유저의 session 정보가 남아있어 생기는 문제였어요. 이전에 동일한 문제가 발생해서 clearAuthCookies로 해결한줄 알았는데 API 호출 에러는 계속 발생하고 있었던걸로 확인했어요. 
그때 해결했던 [YS-424 PR](https://github.com/YAPP-Github/25th-Web-Team-2-FE/pull/112)로 이동하여 확인해보니 clearAuthCookies를 하지 않으면 무한루프가 걸리는데 401은 동일하게 발생하더라구요. 근데 해당 로직이 서버컴포넌트에서 호출되면서 페이지가 노출되지 않는 문제가 발생한걸로 확인했어요. 
따라서 분기처리를 추가하고, 인증되지 않은 유저일 경우 클라이언트 세션을 날리는 로직을 추가했어요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 비인가 세션으로 홈 등 비가입 경로 접근 시 자동 로그아웃 처리로 잘못된 접근을 방지했습니다.
  - 권한 판별을 개선해 비인가 상태가 연구자/참여자 역할로 오인식되던 문제를 줄였습니다.
  - 초기 사용자 정보 로딩 및 사전 패치가 인증된 경우에만 실행되어 불필요한 호출, 로딩 오류, 화면 깜빡임을 완화했습니다.
  - 오류 상태 노출을 보강해 로딩/가져오기 실패 시 더 명확한 피드백을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->