### PR TITLE
[YS-558] 모바일 회원가입 사용자 경험 개선

### DIFF
--- a/src/app/join/components/FunnelStepGuard/FunnelStepGuard.tsx
+++ b/src/app/join/components/FunnelStepGuard/FunnelStepGuard.tsx
@@ -1,5 +1,6 @@
-import useFunnel from '@/app/join/hooks/useFunnel';
 import { PropsWithChildren, useEffect } from 'react';
+
+import useFunnel from '@/app/join/hooks/useFunnel';
 
 interface FunnelStepGuardProps {
   isDirty: boolean;

--- a/src/app/join/components/JoinInput/JoinInput.tsx
+++ b/src/app/join/components/JoinInput/JoinInput.tsx
@@ -59,8 +59,13 @@ interface JoinInputProps<T extends FieldValues> {
   isTip?: boolean;
   inputType?: 'text' | 'date';
   className?: string;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  inputPropRef?:
+    | React.MutableRefObject<HTMLInputElement | null>
+    | ((el: HTMLInputElement | null) => void);
 }
 
+// NOTE: forwardRef 사용하면 제네릭이 원하는대로 정의할 수 없어 inputPropRef로 관리
 const JoinInput = <T extends FieldValues>({
   name,
   control,
@@ -75,10 +80,12 @@ const JoinInput = <T extends FieldValues>({
   isTip = true,
   inputType = 'text',
   className,
+  onKeyDown,
+  inputPropRef,
 }: JoinInputProps<T>) => {
   const [isFocused, setIsFocused] = useState(false);
   const resetButtonRef = useRef<HTMLButtonElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>, onBlur: () => void) => {
     if (resetButtonRef.current && resetButtonRef.current.contains(e.relatedTarget)) {
@@ -112,7 +119,15 @@ const JoinInput = <T extends FieldValues>({
               <input
                 {...field}
                 id={name}
-                ref={inputRef}
+                ref={(el) => {
+                  field.ref(el);
+                  inputRef.current = el;
+                  if (typeof inputPropRef === 'function') {
+                    inputPropRef(el);
+                  } else if (inputPropRef) {
+                    inputPropRef.current = el;
+                  }
+                }}
                 placeholder={placeholder}
                 disabled={disabled}
                 maxLength={maxLength}
@@ -125,6 +140,7 @@ const JoinInput = <T extends FieldValues>({
                 }}
                 onFocus={() => setIsFocused(true)}
                 onBlur={(e) => handleBlur(e, field.onBlur)}
+                onKeyDown={onKeyDown}
               />
               {isFocused && field.value && !disabled && (
                 <button className={inputResetButton} ref={resetButtonRef}>

--- a/src/app/join/components/JoinInput/JoinInput.tsx
+++ b/src/app/join/components/JoinInput/JoinInput.tsx
@@ -143,14 +143,15 @@ const JoinInput = <T extends FieldValues>({
                 onKeyDown={onKeyDown}
               />
               {isFocused && field.value && !disabled && (
-                <button className={inputResetButton} ref={resetButtonRef}>
-                  <Icon
-                    icon="CloseRound"
-                    width={22}
-                    height={22}
-                    onClick={() => handleReset(field.onChange)}
-                    cursor="pointer"
-                  />
+                <button
+                  className={inputResetButton}
+                  ref={resetButtonRef}
+                  onMouseDown={(e) => {
+                    e.preventDefault(); // blur 방지
+                    handleReset(field.onChange);
+                  }}
+                >
+                  <Icon icon="CloseRound" width={22} height={22} cursor="pointer" />
                 </button>
               )}
             </div>

--- a/src/app/join/components/JoinInput/JoinInput.tsx
+++ b/src/app/join/components/JoinInput/JoinInput.tsx
@@ -118,7 +118,7 @@ const JoinInput = <T extends FieldValues>({
                 maxLength={maxLength}
                 aria-invalid={fieldState.invalid ? true : false}
                 style={{ width: '100%' }}
-                className={className ? className : joinInput}
+                className={`${joinInput} ${className ?? ''}`}
                 onChange={(e) => {
                   const formattedValue = formatDateInput(inputType, e.target.value);
                   field.onChange(formattedValue);

--- a/src/app/join/components/JoinTextarea/JoinTextarea.tsx
+++ b/src/app/join/components/JoinTextarea/JoinTextarea.tsx
@@ -24,6 +24,10 @@ interface JoinTextareaProps<T extends FieldValues> {
   value?: PathValue<T, Path<T>>;
   maxLength?: number;
   rows?: number;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  inputPropRef?:
+    | React.MutableRefObject<HTMLTextAreaElement | null>
+    | ((el: HTMLTextAreaElement | null) => void);
 }
 
 const JoinTextarea = <T extends FieldValues>({
@@ -36,6 +40,8 @@ const JoinTextarea = <T extends FieldValues>({
   value,
   maxLength,
   rows = 3,
+  onKeyDown,
+  inputPropRef,
 }: JoinTextareaProps<T>) => {
   const resetButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -64,6 +70,14 @@ const JoinTextarea = <T extends FieldValues>({
               <textarea
                 {...field}
                 id={name}
+                ref={(el) => {
+                  field.ref(el);
+                  if (typeof inputPropRef === 'function') {
+                    inputPropRef(el);
+                  } else if (inputPropRef) {
+                    inputPropRef.current = el;
+                  }
+                }}
                 placeholder={placeholder}
                 disabled={disabled}
                 aria-invalid={fieldState.invalid ? true : false}
@@ -72,6 +86,7 @@ const JoinTextarea = <T extends FieldValues>({
                 style={{ width: '100%' }}
                 className={joinInput}
                 onBlur={(e) => handleBlur(e, field.onBlur)}
+                onKeyDown={onKeyDown}
               />
             </div>
             <div className={infoContainer}>

--- a/src/app/join/desktop/Participant/ParticipantForm.tsx
+++ b/src/app/join/desktop/Participant/ParticipantForm.tsx
@@ -3,16 +3,17 @@
 import { useSession } from 'next-auth/react';
 import { FormProvider } from 'react-hook-form';
 
-import FunnelLayout from '../../components/FunnelLayout/FunnelLayout';
-import { JoinLayout } from '../../components/JoinLayout/JoinLayout';
-import JoinSuccessStep from '../../components/JoinSuccessStep/JoinSuccessStep';
-import useFunnel from '../../hooks/useFunnel';
-import { useParticipantJoin } from '../../hooks/useParticipantJoin';
-import { DESKTOP_PARTICIPANT_JOIN_STEP_LIST, STEP } from '../../JoinPage.constants';
+import FunnelLayout from '@/app/join/components/FunnelLayout/FunnelLayout';
+import { JoinLayout } from '@/app/join/components/JoinLayout/JoinLayout';
+import JoinSuccessStep from '@/app/join/components/JoinSuccessStep/JoinSuccessStep';
+import useFunnel from '@/app/join/hooks/useFunnel';
+import { useParticipantJoin } from '@/app/join/hooks/useParticipantJoin';
+import { DESKTOP_PARTICIPANT_JOIN_STEP_LIST, STEP } from '@/app/join/JoinPage.constants';
 
 import { Participant } from '.';
 
 import { LoginProvider } from '@/types/user';
+import FunnelStepGuard from '@/app/join/components/FunnelStepGuard/FunnelStepGuard';
 
 const ParticipantForm = () => {
   const { FunnelProvider, Funnel, Step, setStep } = useFunnel(DESKTOP_PARTICIPANT_JOIN_STEP_LIST);
@@ -32,19 +33,21 @@ const ParticipantForm = () => {
     <FormProvider {...participantMethods}>
       <JoinLayout.FormGuard>
         <FunnelProvider>
-          <FunnelLayout title="참여자 회원가입">
-            <Funnel>
-              <Step name={STEP.email}>
-                <Participant.EmailStep onNext={() => setStep(STEP.info)} />
-              </Step>
-              <Step name={STEP.info}>
-                <Participant.InfoStep handleSubmit={handleSubmit} />
-              </Step>
-              <Step name={STEP.success}>
-                <JoinSuccessStep />
-              </Step>
-            </Funnel>
-          </FunnelLayout>
+          <FunnelStepGuard isDirty={participantMethods.formState.isDirty}>
+            <FunnelLayout title="참여자 회원가입">
+              <Funnel>
+                <Step name={STEP.email}>
+                  <Participant.EmailStep onNext={() => setStep(STEP.info)} />
+                </Step>
+                <Step name={STEP.info}>
+                  <Participant.InfoStep handleSubmit={handleSubmit} />
+                </Step>
+                <Step name={STEP.success}>
+                  <JoinSuccessStep />
+                </Step>
+              </Funnel>
+            </FunnelLayout>
+          </FunnelStepGuard>
         </FunnelProvider>
       </JoinLayout.FormGuard>
     </FormProvider>

--- a/src/app/join/desktop/Participant/ParticipantForm.tsx
+++ b/src/app/join/desktop/Participant/ParticipantForm.tsx
@@ -3,17 +3,16 @@
 import { useSession } from 'next-auth/react';
 import { FormProvider } from 'react-hook-form';
 
+import { Participant } from '.';
+
 import FunnelLayout from '@/app/join/components/FunnelLayout/FunnelLayout';
+import FunnelStepGuard from '@/app/join/components/FunnelStepGuard/FunnelStepGuard';
 import { JoinLayout } from '@/app/join/components/JoinLayout/JoinLayout';
 import JoinSuccessStep from '@/app/join/components/JoinSuccessStep/JoinSuccessStep';
 import useFunnel from '@/app/join/hooks/useFunnel';
 import { useParticipantJoin } from '@/app/join/hooks/useParticipantJoin';
 import { DESKTOP_PARTICIPANT_JOIN_STEP_LIST, STEP } from '@/app/join/JoinPage.constants';
-
-import { Participant } from '.';
-
 import { LoginProvider } from '@/types/user';
-import FunnelStepGuard from '@/app/join/components/FunnelStepGuard/FunnelStepGuard';
 
 const ParticipantForm = () => {
   const { FunnelProvider, Funnel, Step, setStep } = useFunnel(DESKTOP_PARTICIPANT_JOIN_STEP_LIST);

--- a/src/app/join/desktop/Researcher/ResearcherForm.tsx
+++ b/src/app/join/desktop/Researcher/ResearcherForm.tsx
@@ -3,15 +3,15 @@
 import { useSession } from 'next-auth/react';
 import { FormProvider } from 'react-hook-form';
 
-import FunnelLayout from '../../components/FunnelLayout/FunnelLayout';
-import { JoinLayout } from '../../components/JoinLayout/JoinLayout';
-import JoinSuccessStep from '../../components/JoinSuccessStep/JoinSuccessStep';
-import useFunnel from '../../hooks/useFunnel';
-import { useResearcherJoin } from '../../hooks/useResearcherJoin';
-import { DESKTOP_RESEARCHER_JOIN_STEP_LIST, STEP } from '../../JoinPage.constants';
-
 import { Researcher } from '.';
 
+import FunnelLayout from '@/app/join/components/FunnelLayout/FunnelLayout';
+import FunnelStepGuard from '@/app/join/components/FunnelStepGuard/FunnelStepGuard';
+import { JoinLayout } from '@/app/join/components/JoinLayout/JoinLayout';
+import JoinSuccessStep from '@/app/join/components/JoinSuccessStep/JoinSuccessStep';
+import useFunnel from '@/app/join/hooks/useFunnel';
+import { useResearcherJoin } from '@/app/join/hooks/useResearcherJoin';
+import { DESKTOP_RESEARCHER_JOIN_STEP_LIST, STEP } from '@/app/join/JoinPage.constants';
 import { LoginProvider } from '@/types/user';
 
 const ResearcherForm = () => {
@@ -32,19 +32,21 @@ const ResearcherForm = () => {
     <FormProvider {...researcherMethods}>
       <JoinLayout.FormGuard>
         <FunnelProvider>
-          <FunnelLayout title="연구자 회원가입">
-            <Funnel>
-              <Step name={STEP.email}>
-                <Researcher.EmailStep onNext={() => setStep(STEP.info)} />
-              </Step>
-              <Step name={STEP.info}>
-                <Researcher.InfoStep handleSubmit={handleSubmit} />
-              </Step>
-              <Step name={STEP.success}>
-                <JoinSuccessStep />
-              </Step>
-            </Funnel>
-          </FunnelLayout>
+          <FunnelStepGuard isDirty={researcherMethods.formState.isDirty}>
+            <FunnelLayout title="연구자 회원가입">
+              <Funnel>
+                <Step name={STEP.email}>
+                  <Researcher.EmailStep onNext={() => setStep(STEP.info)} />
+                </Step>
+                <Step name={STEP.info}>
+                  <Researcher.InfoStep handleSubmit={handleSubmit} />
+                </Step>
+                <Step name={STEP.success}>
+                  <JoinSuccessStep />
+                </Step>
+              </Funnel>
+            </FunnelLayout>
+          </FunnelStepGuard>
         </FunnelProvider>
       </JoinLayout.FormGuard>
     </FormProvider>

--- a/src/app/join/hooks/useFocusNavigation.ts
+++ b/src/app/join/hooks/useFocusNavigation.ts
@@ -1,0 +1,37 @@
+import { useRef, useCallback } from 'react';
+
+export const useFocusNavigation = (inputOrder: string[]) => {
+  const inputRefs = useRef<Record<string, HTMLInputElement | null>>({});
+
+  const focusNextInput = useCallback(
+    (currentInputName: string) => {
+      const currentIndex = inputOrder.indexOf(currentInputName);
+      const nextIndex = currentIndex + 1;
+
+      if (nextIndex < inputOrder.length) {
+        const nextInputName = inputOrder[nextIndex];
+        inputRefs.current[nextInputName]?.focus();
+      }
+    },
+    [inputOrder],
+  );
+
+  const handleKeyDown = useCallback(
+    (inputName: string) => (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        focusNextInput(inputName);
+      }
+    },
+    [focusNextInput],
+  );
+
+  const setInputRef = useCallback(
+    (inputName: string) => (el: HTMLInputElement | null) => {
+      inputRefs.current[inputName] = el;
+    },
+    [],
+  );
+
+  return { handleKeyDown, setInputRef };
+};

--- a/src/app/join/hooks/useFocusNavigation.ts
+++ b/src/app/join/hooks/useFocusNavigation.ts
@@ -1,7 +1,7 @@
 import { useRef, useCallback } from 'react';
 
 export const useFocusNavigation = (inputOrder: string[]) => {
-  const inputRefs = useRef<Record<string, HTMLInputElement | null>>({});
+  const inputRefs = useRef<Record<string, HTMLInputElement | HTMLTextAreaElement | null>>({});
 
   const focusNextInput = useCallback(
     (currentInputName: string) => {
@@ -17,7 +17,7 @@ export const useFocusNavigation = (inputOrder: string[]) => {
   );
 
   const handleKeyDown = useCallback(
-    (inputName: string) => (e: React.KeyboardEvent<HTMLInputElement>) => {
+    (inputName: string) => (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       if (e.key === 'Enter') {
         e.preventDefault();
         focusNextInput(inputName);
@@ -27,7 +27,7 @@ export const useFocusNavigation = (inputOrder: string[]) => {
   );
 
   const setInputRef = useCallback(
-    (inputName: string) => (el: HTMLInputElement | null) => {
+    (inputName: string) => (el: HTMLInputElement | HTMLTextAreaElement | null) => {
       inputRefs.current[inputName] = el;
     },
     [],

--- a/src/app/join/hooks/useFunnel.tsx
+++ b/src/app/join/hooks/useFunnel.tsx
@@ -38,6 +38,7 @@ interface FunnelState<T extends Steps = Steps> {
   setStep: (step: T[number]) => void;
   goToPrev: () => void;
   goToNext: () => void;
+  goToFirstStep: () => void;
 }
 
 /**
@@ -53,6 +54,7 @@ const FunnelContext = createContext<FunnelState | null>(null);
  * @returns setStep: currentStep 설정하는 함수
  * @returns goToPrev: 이전 step으로 이동하는 함수
  * @returns goToNext: 다음 step으로 이동하는 함수
+ * @returns goToFirstStep: 첫 번째 step으로 이동하는 함수
  * @returns step: currentStep
  * @returns steps: 모든 step 배열
  * @returns currentStepIdx: 현재 단계 idx
@@ -100,6 +102,12 @@ const useFunnel = <T extends Steps>(steps?: T): UseFunnelReturn<T> => {
     }
   }, [isLast, targetSteps, currentStepIdx, setStep]);
 
+  const goToFirstStep = useCallback(() => {
+    if (targetSteps.length > 0) {
+      setStep(targetSteps[0]);
+    }
+  }, [targetSteps, setStep]);
+
   const FunnelProvider = useMemo(() => {
     const ProviderComponent = ({ children }: { children: ReactNode }) => {
       const contextValue = {
@@ -111,6 +119,7 @@ const useFunnel = <T extends Steps>(steps?: T): UseFunnelReturn<T> => {
         setStep,
         goToPrev,
         goToNext,
+        goToFirstStep,
       };
 
       return <FunnelContext.Provider value={contextValue}>{children}</FunnelContext.Provider>;
@@ -154,6 +163,7 @@ const useFunnel = <T extends Steps>(steps?: T): UseFunnelReturn<T> => {
     progress,
     goToPrev,
     goToNext,
+    goToFirstStep,
   } as const;
 };
 

--- a/src/app/join/mobile/Participant/ContactEmailStep/ContactEmailStep.tsx
+++ b/src/app/join/mobile/Participant/ContactEmailStep/ContactEmailStep.tsx
@@ -49,6 +49,7 @@ const ContactEmailStep = ({ onNext, provider, oauthEmail }: ContactEmailStepProp
         contactEmailField="contactEmail"
         verifiedEmailField="verifiedContactEmail"
         onSuccess={openServiceAgreeBottomSheet}
+        autoFocus
       />
       <NextButton onNext={onNext} openServiceAgreeBottomSheet={openServiceAgreeBottomSheet} />
     </main>

--- a/src/app/join/mobile/Participant/JoinInfoStep/JoinInfoStep.tsx
+++ b/src/app/join/mobile/Participant/JoinInfoStep/JoinInfoStep.tsx
@@ -6,6 +6,7 @@ import { bottomButtonLayout, emailInput, mainContentLayout } from '../../page.cs
 
 import JoinInput from '@/app/join/components/JoinInput/JoinInput';
 import RadioButtonGroupContainer from '@/app/join/desktop/Participant/JoinInfoStep/RadioButtonGroupContainer/RadioButtonGroupContainer';
+import { useFocusNavigation } from '@/app/join/hooks/useFocusNavigation';
 import { Gender } from '@/app/join/JoinPage.types';
 import Button from '@/components/Button/Button';
 import { ParticipantJoinSchemaType } from '@/schema/join/ParticipantJoinSchema';
@@ -28,6 +29,8 @@ const JoinInfoStep = ({ onNext }: JoinInfoStepProps) => {
 
   const isValid = values.every((value) => (value ?? '').trim() !== '' && value !== undefined);
   const isError = Object.keys(errors).length > 0;
+  const inputOrder = ['name', 'birthDate'];
+  const { handleKeyDown, setInputRef } = useFocusNavigation(inputOrder);
 
   return (
     <main className={mainContentLayout}>
@@ -45,6 +48,8 @@ const JoinInfoStep = ({ onNext }: JoinInfoStepProps) => {
           name="name"
           placeholder="이름을 입력해 주세요"
           required
+          inputPropRef={setInputRef('name')}
+          onKeyDown={handleKeyDown('name')}
         />
 
         {/* 생년월일 */}
@@ -55,6 +60,8 @@ const JoinInfoStep = ({ onNext }: JoinInfoStepProps) => {
           name="birthDate"
           placeholder="YYYY. MM. DD"
           required
+          inputPropRef={setInputRef('birthDate')}
+          onKeyDown={handleKeyDown('birthDate')}
         />
 
         {/* 성별 */}

--- a/src/app/join/mobile/Participant/JoinInfoStep/JoinInfoStep.tsx
+++ b/src/app/join/mobile/Participant/JoinInfoStep/JoinInfoStep.tsx
@@ -11,6 +11,8 @@ import { Gender } from '@/app/join/JoinPage.types';
 import Button from '@/components/Button/Button';
 import { ParticipantJoinSchemaType } from '@/schema/join/ParticipantJoinSchema';
 
+const inputOrder = ['name', 'birthDate'];
+
 interface JoinInfoStepProps {
   onNext: () => void;
 }
@@ -21,6 +23,7 @@ const JoinInfoStep = ({ onNext }: JoinInfoStepProps) => {
     setValue,
     formState: { errors },
   } = useFormContext<ParticipantJoinSchemaType>();
+  const { handleKeyDown, setInputRef } = useFocusNavigation(inputOrder);
 
   const values = useWatch({
     name: ['name', 'birthDate', 'gender'],
@@ -29,8 +32,6 @@ const JoinInfoStep = ({ onNext }: JoinInfoStepProps) => {
 
   const isValid = values.every((value) => (value ?? '').trim() !== '' && value !== undefined);
   const isError = Object.keys(errors).length > 0;
-  const inputOrder = ['name', 'birthDate'];
-  const { handleKeyDown, setInputRef } = useFocusNavigation(inputOrder);
 
   return (
     <main className={mainContentLayout}>

--- a/src/app/join/mobile/Participant/ParticipantForm.tsx
+++ b/src/app/join/mobile/Participant/ParticipantForm.tsx
@@ -12,6 +12,7 @@ import MobileFunnelLayout from '../components/MobileFunnelLayout/MobileFunnelLay
 import { Participant } from '.';
 
 import { LoginProvider } from '@/types/user';
+import FunnelStepGuard from '../components/FunnelStepGuard/FunnelStepGuard';
 
 const ParticipantForm = () => {
   const { data: session } = useSession();
@@ -32,26 +33,28 @@ const ParticipantForm = () => {
   return (
     <FormProvider {...participantMethods}>
       <FunnelProvider>
-        <MobileFunnelLayout title="참여자 회원가입">
-          <Funnel>
-            <Step name={STEP.contactEmail}>
-              <Participant.ContactEmailStep
-                provider={provider}
-                oauthEmail={oauthEmail}
-                onNext={goToNext}
-              />
-            </Step>
-            <Step name={STEP.info}>
-              <Participant.JoinInfoStep onNext={goToNext} />
-            </Step>
-            <Step name={STEP.additionalInfo}>
-              <Participant.JoinAdditionalInfoStep onSubmit={handleSubmit} />
-            </Step>
-            <Step name={STEP.success}>
-              <JoinSuccessStep />
-            </Step>
-          </Funnel>
-        </MobileFunnelLayout>
+        <FunnelStepGuard isDirty={participantMethods.formState.isDirty}>
+          <MobileFunnelLayout title="참여자 회원가입">
+            <Funnel>
+              <Step name={STEP.contactEmail}>
+                <Participant.ContactEmailStep
+                  provider={provider}
+                  oauthEmail={oauthEmail}
+                  onNext={goToNext}
+                />
+              </Step>
+              <Step name={STEP.info}>
+                <Participant.JoinInfoStep onNext={goToNext} />
+              </Step>
+              <Step name={STEP.additionalInfo}>
+                <Participant.JoinAdditionalInfoStep onSubmit={handleSubmit} />
+              </Step>
+              <Step name={STEP.success}>
+                <JoinSuccessStep />
+              </Step>
+            </Funnel>
+          </MobileFunnelLayout>
+        </FunnelStepGuard>
       </FunnelProvider>
     </FormProvider>
   );

--- a/src/app/join/mobile/Participant/ParticipantForm.tsx
+++ b/src/app/join/mobile/Participant/ParticipantForm.tsx
@@ -3,16 +3,15 @@
 import { useSession } from 'next-auth/react';
 import { FormProvider } from 'react-hook-form';
 
-import JoinSuccessStep from '../../components/JoinSuccessStep/JoinSuccessStep';
-import useFunnel from '../../hooks/useFunnel';
-import { useParticipantJoin } from '../../hooks/useParticipantJoin';
-import { MOBILE_PARTICIPANT_JOIN_STEP_LIST, STEP } from '../../JoinPage.constants';
-import MobileFunnelLayout from '../components/MobileFunnelLayout/MobileFunnelLayout';
-
 import { Participant } from '.';
 
+import FunnelStepGuard from '@/app/join/components/FunnelStepGuard/FunnelStepGuard';
+import JoinSuccessStep from '@/app/join/components/JoinSuccessStep/JoinSuccessStep';
+import useFunnel from '@/app/join/hooks/useFunnel';
+import { useParticipantJoin } from '@/app/join/hooks/useParticipantJoin';
+import { MOBILE_PARTICIPANT_JOIN_STEP_LIST, STEP } from '@/app/join/JoinPage.constants';
+import MobileFunnelLayout from '@/app/join/mobile/components/MobileFunnelLayout/MobileFunnelLayout';
 import { LoginProvider } from '@/types/user';
-import FunnelStepGuard from '../components/FunnelStepGuard/FunnelStepGuard';
 
 const ParticipantForm = () => {
   const { data: session } = useSession();

--- a/src/app/join/mobile/Researcher/ContactEmailStep/ContactEmailStep.tsx
+++ b/src/app/join/mobile/Researcher/ContactEmailStep/ContactEmailStep.tsx
@@ -30,6 +30,7 @@ const ContactEmailStep = ({ provider, oauthEmail, onNext }: ContactEmailStepProp
         contactEmailField="contactEmail"
         verifiedEmailField="verifiedContactEmail"
         onSuccess={onNext}
+        autoFocus
       />
       <NextButton onNext={onNext} />
     </main>

--- a/src/app/join/mobile/Researcher/JoinInfoStep/JoinInfoStep.tsx
+++ b/src/app/join/mobile/Researcher/JoinInfoStep/JoinInfoStep.tsx
@@ -7,7 +7,10 @@ import { bottomButtonLayout, mainContentLayout } from '../../page.css';
 import JoinButton from '@/app/join/components/JoinButton/JoinButton';
 import JoinInput from '@/app/join/components/JoinInput/JoinInput';
 import JoinTextarea from '@/app/join/components/JoinTextarea/JoinTextarea';
+import { useFocusNavigation } from '@/app/join/hooks/useFocusNavigation';
 import { ResearcherJoinSchemaType } from '@/schema/join/ResearcherJoinSchema';
+
+const inputOrder = ['name', 'univName', 'major', 'labInfo'];
 
 interface JoinInfoStepProps {
   onSubmit: () => void;
@@ -15,6 +18,7 @@ interface JoinInfoStepProps {
 
 const JoinInfoStep = ({ onSubmit }: JoinInfoStepProps) => {
   const { control } = useFormContext<ResearcherJoinSchemaType>();
+  const { handleKeyDown, setInputRef } = useFocusNavigation(inputOrder);
 
   return (
     <main className={mainContentLayout}>
@@ -31,6 +35,8 @@ const JoinInfoStep = ({ onSubmit }: JoinInfoStepProps) => {
           label="이름"
           required
           placeholder="이름(실명) 입력"
+          inputPropRef={setInputRef('name')}
+          onKeyDown={handleKeyDown('name')}
         />
 
         {/* 학교명 */}
@@ -40,6 +46,8 @@ const JoinInfoStep = ({ onSubmit }: JoinInfoStepProps) => {
           label="학교명"
           required
           placeholder="학교명 입력"
+          inputPropRef={setInputRef('univName')}
+          onKeyDown={handleKeyDown('univName')}
         />
 
         {/* 전공명 */}
@@ -49,6 +57,8 @@ const JoinInfoStep = ({ onSubmit }: JoinInfoStepProps) => {
           label="전공명"
           required
           placeholder="전공명 입력"
+          inputPropRef={setInputRef('major')}
+          onKeyDown={handleKeyDown('major')}
         />
 
         {/* 소속 연구실 정보 */}
@@ -58,6 +68,8 @@ const JoinInfoStep = ({ onSubmit }: JoinInfoStepProps) => {
           label="소속 연구실 정보"
           placeholder="연구실 정보 입력"
           maxLength={100}
+          inputPropRef={setInputRef('labInfo')}
+          onKeyDown={handleKeyDown('labInfo')}
         />
       </div>
 

--- a/src/app/join/mobile/Researcher/ResearcherForm.tsx
+++ b/src/app/join/mobile/Researcher/ResearcherForm.tsx
@@ -3,16 +3,15 @@
 import { useSession } from 'next-auth/react';
 import { FormProvider } from 'react-hook-form';
 
-import JoinSuccessStep from '../../components/JoinSuccessStep/JoinSuccessStep';
-import useFunnel from '../../hooks/useFunnel';
-import { useResearcherJoin } from '../../hooks/useResearcherJoin';
-import { MOBILE_RESEARCHER_JOIN_STEP_LIST, STEP } from '../../JoinPage.constants';
-import MobileFunnelLayout from '../components/MobileFunnelLayout/MobileFunnelLayout';
-
 import { Researcher } from '.';
 
+import FunnelStepGuard from '@/app/join/components/FunnelStepGuard/FunnelStepGuard';
+import JoinSuccessStep from '@/app/join/components/JoinSuccessStep/JoinSuccessStep';
+import useFunnel from '@/app/join/hooks/useFunnel';
+import { useResearcherJoin } from '@/app/join/hooks/useResearcherJoin';
+import { MOBILE_RESEARCHER_JOIN_STEP_LIST, STEP } from '@/app/join/JoinPage.constants';
+import MobileFunnelLayout from '@/app/join/mobile/components/MobileFunnelLayout/MobileFunnelLayout';
 import { LoginProvider } from '@/types/user';
-import FunnelStepGuard from '../components/FunnelStepGuard/FunnelStepGuard';
 
 const ResearcherForm = () => {
   const { data: session } = useSession();

--- a/src/app/join/mobile/Researcher/ResearcherForm.tsx
+++ b/src/app/join/mobile/Researcher/ResearcherForm.tsx
@@ -12,6 +12,7 @@ import MobileFunnelLayout from '../components/MobileFunnelLayout/MobileFunnelLay
 import { Researcher } from '.';
 
 import { LoginProvider } from '@/types/user';
+import FunnelStepGuard from '../components/FunnelStepGuard/FunnelStepGuard';
 
 const ResearcherForm = () => {
   const { data: session } = useSession();
@@ -32,26 +33,28 @@ const ResearcherForm = () => {
   return (
     <FormProvider {...researcherMethods}>
       <FunnelProvider>
-        <MobileFunnelLayout title="연구자 회원가입">
-          <Funnel>
-            <Step name={STEP.contactEmail}>
-              <Researcher.ContactEmailStep
-                provider={provider}
-                oauthEmail={oauthEmail}
-                onNext={goToNext}
-              />
-            </Step>
-            <Step name={STEP.univEmail}>
-              <Researcher.UnivEmailStep onNext={goToNext} />
-            </Step>
-            <Step name={STEP.info}>
-              <Researcher.JoinInfoStep onSubmit={handleSubmit} />
-            </Step>
-            <Step name={STEP.success}>
-              <JoinSuccessStep />
-            </Step>
-          </Funnel>
-        </MobileFunnelLayout>
+        <FunnelStepGuard isDirty={researcherMethods.formState.isDirty}>
+          <MobileFunnelLayout title="연구자 회원가입">
+            <Funnel>
+              <Step name={STEP.contactEmail}>
+                <Researcher.ContactEmailStep
+                  provider={provider}
+                  oauthEmail={oauthEmail}
+                  onNext={goToNext}
+                />
+              </Step>
+              <Step name={STEP.univEmail}>
+                <Researcher.UnivEmailStep onNext={goToNext} />
+              </Step>
+              <Step name={STEP.info}>
+                <Researcher.JoinInfoStep onSubmit={handleSubmit} />
+              </Step>
+              <Step name={STEP.success}>
+                <JoinSuccessStep />
+              </Step>
+            </Funnel>
+          </MobileFunnelLayout>
+        </FunnelStepGuard>
       </FunnelProvider>
     </FormProvider>
   );

--- a/src/app/join/mobile/components/FunnelStepGuard/FunnelStepGuard.tsx
+++ b/src/app/join/mobile/components/FunnelStepGuard/FunnelStepGuard.tsx
@@ -1,0 +1,23 @@
+import useFunnel from '@/app/join/hooks/useFunnel';
+import { PropsWithChildren, useEffect } from 'react';
+
+interface FunnelStepGuardProps {
+  isDirty: boolean;
+}
+
+/**
+ * 폼데이터가 없을 경우 첫 번째 step으로 이동시키는 기능성 컴포넌트
+ */
+const FunnelStepGuard = ({ children, isDirty }: PropsWithChildren<FunnelStepGuardProps>) => {
+  const { currentStepIdx, goToFirstStep } = useFunnel();
+
+  useEffect(() => {
+    if (currentStepIdx > 0 && !isDirty) {
+      goToFirstStep();
+    }
+  }, [currentStepIdx]);
+
+  return <>{children}</>;
+};
+
+export default FunnelStepGuard;

--- a/src/app/join/mobile/layout.tsx
+++ b/src/app/join/mobile/layout.tsx
@@ -1,4 +1,13 @@
+import type { Viewport } from 'next';
+
 import { mobileJoinPageLayout } from '../JoinPage.css';
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  // maximumScale: 1,
+  // userScalable: false,
+};
 
 export default function MobileJoinLayout({ children }: { children: React.ReactNode }) {
   return <div className={mobileJoinPageLayout}>{children}</div>;

--- a/src/app/join/mobile/page.css.ts
+++ b/src/app/join/mobile/page.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
 
 import { colors } from '@/styles/colors';
 import { fonts } from '@/styles/fonts.css';
@@ -74,6 +74,10 @@ export const checkboxWrapper = style({
   padding: '0.6rem 0',
   textAlign: 'left',
   wordBreak: 'keep-all',
+});
+
+globalStyle(`${checkboxWrapper} label`, {
+  alignItems: 'flex-start',
 });
 
 export const bottomButtonLayout = style({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -48,6 +48,10 @@ export const metadata: Metadata = {
       'naver-site-verification': '30b0a9ec0a357ce934c3c90cf68aedd57b8ad2fd',
     },
   },
+  formatDetection: {
+    telephone: false,
+    email: false,
+  },
 };
 
 export default async function RootLayout({

--- a/src/app/user/profile/mobile/edit/[infoType]/components/Participant/ContactEmailEditForm/ContactEmailEditForm.tsx
+++ b/src/app/user/profile/mobile/edit/[infoType]/components/Participant/ContactEmailEditForm/ContactEmailEditForm.tsx
@@ -39,6 +39,7 @@ const ContactEmailEditForm = ({ userInfo }: ContactEmailEditFormProps) => {
           contactEmailField="contactEmail"
           verifiedEmailField="verifiedContactEmail"
           joinedUser
+          autoFocus
         />
         <SaveButton
           onSave={onSubmit}

--- a/src/app/user/profile/mobile/edit/[infoType]/components/Researcher/ContactEmailEditForm/ContactEmailEditForm.tsx
+++ b/src/app/user/profile/mobile/edit/[infoType]/components/Researcher/ContactEmailEditForm/ContactEmailEditForm.tsx
@@ -39,6 +39,7 @@ const ContactEmailEditForm = ({ userInfo }: ContactEmailEditFormProps) => {
           contactEmailField="contactEmail"
           verifiedEmailField="verifiedContactEmail"
           joinedUser
+          autoFocus
         />
         <SaveButton<ResearcherUpdateSchemaType>
           onSave={onSubmit}

--- a/src/components/ButtonInput/ButtonInput.tsx
+++ b/src/components/ButtonInput/ButtonInput.tsx
@@ -80,6 +80,11 @@ const ButtonInput = <T extends FieldValues>({
             field.onBlur();
           };
 
+          const handleClick = () => {
+            onClick(); // 중복 확인 로직 실행
+            field.onBlur(); // 모바일에서 버튼 클릭 시 인풋 포커스 해제하여 가상키보드 닫기
+          };
+
           return (
             <>
               <div className={inputWrapper}>
@@ -100,7 +105,7 @@ const ButtonInput = <T extends FieldValues>({
                     type="button"
                     className={confirmButton}
                     disabled={isButtonDisabled || isLoading}
-                    onClick={onClick}
+                    onClick={handleClick}
                     onMouseDown={(e) => e.preventDefault()}
                     ref={validateButtonRef}
                   >

--- a/src/components/ButtonInput/ButtonInput.tsx
+++ b/src/components/ButtonInput/ButtonInput.tsx
@@ -92,9 +92,9 @@ const ButtonInput = <T extends FieldValues>({
                   {...field}
                   id={name}
                   style={{ width: '100%' }}
-                  className={className ? className : joinInput}
+                  className={`${joinInput} ${className ?? ''}`}
                   placeholder={placeholder}
-                  aria-invalid={fieldState.invalid ? true : false}
+                  aria-invalid={fieldState.invalid}
                   onChange={handleChange}
                   onBlur={handleBlur}
                   autoFocus={autoFocus}

--- a/src/components/ButtonInput/ButtonInput.tsx
+++ b/src/components/ButtonInput/ButtonInput.tsx
@@ -47,6 +47,7 @@ const ButtonInput = <T extends FieldValues>({
 }: ButtonInputProps<T>) => {
   const { trigger } = useFormContext<T>();
   const validateButtonRef = useRef<HTMLButtonElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
   const [_, startTransition] = useTransition();
 
   return (
@@ -82,6 +83,7 @@ const ButtonInput = <T extends FieldValues>({
 
           const handleClick = () => {
             onClick(); // 중복 확인 로직 실행
+            inputRef.current?.blur(); //실제 DOM 포커스 해제하여 가상키보드 닫기
             field.onBlur(); // 모바일에서 버튼 클릭 시 인풋 포커스 해제하여 가상키보드 닫기
           };
 
@@ -91,6 +93,10 @@ const ButtonInput = <T extends FieldValues>({
                 <input
                   {...field}
                   id={name}
+                  ref={(el) => {
+                    field.ref(el);
+                    inputRef.current = el;
+                  }}
                   style={{ width: '100%' }}
                   className={`${joinInput} ${className ?? ''}`}
                   placeholder={placeholder}

--- a/src/components/ButtonInput/ButtonInput.tsx
+++ b/src/components/ButtonInput/ButtonInput.tsx
@@ -28,6 +28,7 @@ interface ButtonInputProps<T extends FieldValues> {
   isTip?: boolean;
   isButtonHidden?: boolean;
   placeholder?: string;
+  autoFocus?: boolean;
 }
 
 const ButtonInput = <T extends FieldValues>({
@@ -42,6 +43,7 @@ const ButtonInput = <T extends FieldValues>({
   isTip = false,
   isButtonHidden = false,
   placeholder = '이메일 입력',
+  autoFocus = false,
 }: ButtonInputProps<T>) => {
   const { trigger } = useFormContext<T>();
   const validateButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -90,6 +92,7 @@ const ButtonInput = <T extends FieldValues>({
                   aria-invalid={fieldState.invalid ? true : false}
                   onChange={handleChange}
                   onBlur={handleBlur}
+                  autoFocus={autoFocus}
                 />
 
                 {!isButtonHidden && (

--- a/src/components/ContactEmailInput/ContactEmailInput.tsx
+++ b/src/components/ContactEmailInput/ContactEmailInput.tsx
@@ -14,6 +14,7 @@ interface ContactEmailInputProps<T extends FieldValues> {
   required?: boolean;
   onSuccess?: () => void;
   joinedUser?: boolean;
+  autoFocus?: boolean;
 }
 
 const ContactEmailInput = <T extends FieldValues>({
@@ -25,6 +26,7 @@ const ContactEmailInput = <T extends FieldValues>({
   required = false,
   joinedUser = false,
   onSuccess,
+  autoFocus = false,
 }: ContactEmailInputProps<T>) => {
   const toast = useToast();
   const { control, getValues, setValue } = useFormContext<T>();
@@ -64,6 +66,7 @@ const ContactEmailInput = <T extends FieldValues>({
       isButtonHidden={isVerified}
       tip={helperText}
       isTip={isTip}
+      autoFocus={autoFocus}
     />
   );
 };

--- a/src/styles/reset.css.ts
+++ b/src/styles/reset.css.ts
@@ -1,5 +1,6 @@
 import { globalStyle } from '@vanilla-extract/css';
 
+import { colors } from './colors';
 import * as layers from './layers.css';
 
 /**
@@ -56,6 +57,15 @@ globalStyle('button', {
       background: 'none',
       outline: 'none',
       cursor: 'pointer',
+      color: 'inherit',
+    },
+  },
+});
+
+globalStyle('button:enabled', {
+  '@layer': {
+    [layers.reset]: {
+      color: colors.text06,
     },
   },
 });


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->
closed #243 

## As-Is
<!-- 문제 상황 정의 -->
- 모바일 회원가입 진행 시 불편한 부분 존재

## To-Be
<!-- 변경 사항 -->
- [x] 모바일 회원가입 autoFocus 적용
- [x] 메일 링크 제거
- [x] IOS 인풋 자동 줌인 제거 (16px로 조정하여 모바일 인풋 클릭 시 확대 제거)
- [x] 새로고침 등으로 인해 폼데이터가 유실된 경우 첫 화면으로 이동
- [x] 중복 확인 버튼 클릭 시 가상 키보드 제거
- [x] 인풋 리셋 동작 오류 수정
- [x] IOS 라디오 버튼 색상 검은색 변경
- [x] 모바일 회원가입 입력할 때 엔터하면 다음 입력으로 넘어가도록 처리
- [x] 바텀시트 체크박스 상단 정렬 (텍스트가 줄바꿈될 경우 어색)

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description

### autoFocus

autoFocus props 추가

### 메일 링크 제거

```
export const metadata: Metadata = {
  ...,
  formatDetection: {
    telephone: false,
    email: false,
  },
};
```

```
<meta name="format-detection" content="telephone=no, address=no, email=no"> 
```

### IOS 인풋 자동 줌인 제거

- 16px로 조정하려고 했는데 이미 16px
- viewport 옵션 추가해서 배포 후 확인 필요
  - 필요 시 maximumScale, userScalable 추가

```tsx
export const viewport: Viewport = {
  width: 'device-width',
  initialScale: 1,
  // maximumScale: 1,
  // userScalable: false,
};
```
### 새로고침 등으로 인해 폼데이터가 유실된 경우 첫 화면으로 이동

폼데이터가 유실될 경우 첫 화면으로 라우팅시키는 FunnelStepGuard 기능성 컴포넌트 구현했어요. defaultValue에서 변경된 경우 isDirty를 true로 반환하기 때문에 이 값으로 체크하였고, 첫번째 index가 아닌 경우에 체크했어요. 이전 PR에서 도입한 FunnelContext 덕분에 currentStepIdx, goToFirstStep을 주입받지 않고 각 Funnel에 유연하게 대응할 수 있었어요.

```tsx
const FunnelStepGuard = ({ children, isDirty }: PropsWithChildren<FunnelStepGuardProps>) => {
  const { currentStepIdx, goToFirstStep } = useFunnel();

  useEffect(() => {
    if (currentStepIdx > 0 && !isDirty) {
      goToFirstStep();
    }
  }, [currentStepIdx]);

  return <>{children}</>;
};
```

### 중복 확인 버튼 클릭 시 가상 키보드 제거

중복 확인 버튼이 input 위에 있어 기존에 input에서 blur되는 시점에 버튼을 눌렀을 때는 blur가 안되고 "중복 확인" 버튼이 클릭되도록 처리했어요. 
이로 인해 오히려 버튼을 클릭했을 때 input의 포커스가 풀리지 않아서 모바일(IOS)에선 가상키보드가 내려가지 않는 현상이 발생했어요. 이를 클릭한 이후에 직접 blur를 실행시켰는데 배포 후 정상동작 확인이 필요해요. onClick 실행 결과가 blur에 영향을 받으면 문제가 되는 로직이지만, 실행 결과에 상관없이 focus를 벗어나게 하는 게 목적이라 유지했어요.

```ts
const handleClick = () => {
  onClick(); // 중복 확인 로직 실행
  field.onBlur(); // 모바일에서 버튼 클릭 시 인풋 포커스 해제하여 가상키보드 닫기
};
```

### 인풋 리셋 동작 오류 수정

touch -> blur -> click 순서로 이벤트가 동작하여 blur시점에 resetButton이 존재하지 않아 클릭 이벤트가 동작하지 않은 걸로 이해했어요. blur 되기 전에 발생하는 mousedown에서 reset을 실행하여 의도한 동작을 실행했어요.

```tsx
onMouseDown={(e) => {
  e.preventDefault(); // blur 방지
  handleReset(field.onChange);
}}
```

### IOS 라디오 버튼 색상 검은색 변경

button 텍스트가 ios에서 파란색으로 보이는 문제가 있어 활성화 상태일 때 기본 버튼 텍스트 색상을 추가했어요.

```tsx
globalStyle('button', {
  '@layer': {
    [layers.reset]: {
     ...
      color: 'inherit',
    },
  },
});

globalStyle('button:enabled', {
  '@layer': {
    [layers.reset]: {
      color: colors.text06,
    },
  },
});
```

### 모바일 회원가입 입력할 때 엔터하면 다음 입력으로 넘어가도록 처리

단순하게는 모든 input에 대해 ref를 생성한 후 다음 input에 포커싱하도록 처리할 수 있었어요. 다만 그럴경우 input이 많을 때는 input 개수만큼 외부에 useRef와 handleKeyDown 이벤트핸들러를 선언해야 했어요. 이를 좀더 추상화하여 다음 input에 포커싱 할 수 있도록 useFocusNavigation을 만들었어요. inputOrder를 정의하고 내부에서 index만 관리하여 다음 인풋으로 포커스를 넘겨주도록 처리했어요.

이렇게 구현한 상태도 사실 완전하진 않아요. 매번 inputPropRef, onKeyDown에 콜백을 주입해주긴 해야돼요. 그래서 원하는 방향은 inputPropRef와 onKeyDown도 주입하지 않고 화면에 그려진 순서대로 인지되도록 Provider 역할을 하는 컴포넌트를 만드는 방향도 고려했어요. next 환경이니까 document.querySelector를 사용하지 않고 구현을 하고 싶은데 원하는 구조대로 구현이 되지 않아 추후에 리팩토링해보려고 해요!

```tsx
export const useFocusNavigation = (inputOrder: string[]) => {
  const inputRefs = useRef<Record<string, HTMLInputElement | HTMLTextAreaElement | null>>({});

  const focusNextInput = useCallback(
    (currentInputName: string) => {
      const currentIndex = inputOrder.indexOf(currentInputName);
      const nextIndex = currentIndex + 1;

      if (nextIndex < inputOrder.length) {
        const nextInputName = inputOrder[nextIndex];
        inputRefs.current[nextInputName]?.focus();
      }
    },
    [inputOrder],
  );

  const handleKeyDown = useCallback(
    (inputName: string) => (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
      if (e.key === 'Enter') {
        e.preventDefault();
        focusNextInput(inputName);
      }
    },
    [focusNextInput],
  );

  const setInputRef = useCallback(
    (inputName: string) => (el: HTMLInputElement | HTMLTextAreaElement | null) => {
      inputRefs.current[inputName] = el;
    },
    [],
  );

  return { handleKeyDown, setInputRef };
};
```

```tsx
const inputOrder = ['name', 'birthDate'];

const JoinInfoStep = ({ onNext }: JoinInfoStepProps) => {
  const { handleKeyDown, setInputRef } = useFocusNavigation(inputOrder);

  return (
    <main className={mainContentLayout}>
      <div className={joinInputContainer}>
        {/* 이름 */}
        <JoinInput
          ...
          inputPropRef={setInputRef('name')}
          onKeyDown={handleKeyDown('name')}
        />

        {/* 생년월일 */}
        <JoinInput
          ...
          inputPropRef={setInputRef('birthDate')}
          onKeyDown={handleKeyDown('birthDate')}
        />
      </div>
    </main>
  );
};
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 가입 폼에서 Enter로 다음 입력란으로 이동하는 키보드 내비게이션 추가
  - 연락처 이메일 입력란에 자동 포커스 지원(모바일 가입 및 프로필 편집)
  - 단계 가드 도입으로 시작 전 단계 접근 방지 및 흐름 안정화
  - 버튼형 입력에 자동 포커스 지원 및 클릭 후 키보드 자동 닫힘

- 스타일
  - 체크박스 라벨 정렬 개선
  - 버튼 텍스트 색상 일관성 향상

- 작업
  - 모바일 레이아웃 뷰포트 설정 추가
  - 전화/이메일 자동 감지 비활성화로 예기치 않은 링크화 방지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->