### PR TITLE
[YS-560] 생년월일 입력 시 온점 자동입력 기능 구현

### DIFF
--- a/src/app/join/components/JoinInput/JoinInput.tsx
+++ b/src/app/join/components/JoinInput/JoinInput.tsx
@@ -67,20 +67,7 @@ const JoinInput = <T extends FieldValues>({
   const previousValueRef = useRef('');
   const previousCursorRef = useRef<number | null>(null);
 
-  const handleBlur = (e: React.FocusEvent<HTMLInputElement>, onBlur: () => void) => {
-    if (resetButtonRef.current && resetButtonRef.current.contains(e.relatedTarget)) {
-      return;
-    }
-    onBlur();
-    setIsFocused(false);
-  };
-
-  const handleReset = (onChange: (value: string) => void) => {
-    onChange('');
-    inputRef.current?.focus();
-  };
-
-  // '.' 을 지웠을 때 커서 위치 조정을 위한 useEffect
+  // 온점을 지웠을 때 커서 위치 조정을 위한 useEffect
   useEffect(() => {
     if (pendingCursorPosition !== null && inputRef.current?.setSelectionRange) {
       inputRef.current.setSelectionRange(pendingCursorPosition, pendingCursorPosition);
@@ -102,6 +89,19 @@ const JoinInput = <T extends FieldValues>({
         rules={rules}
         defaultValue={value}
         render={({ field, fieldState }) => {
+          const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+            if (resetButtonRef.current && resetButtonRef.current.contains(e.relatedTarget)) {
+              return;
+            }
+            field.onBlur();
+            setIsFocused(false);
+          };
+
+          const handleReset = () => {
+            field.onChange('');
+            inputRef.current?.focus();
+          };
+
           const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
             if (inputType === 'date') {
               previousValueRef.current = field.value || '';
@@ -170,7 +170,7 @@ const JoinInput = <T extends FieldValues>({
                   onChange={handleChange}
                   onKeyDown={handleKeyDown}
                   onFocus={() => setIsFocused(true)}
-                  onBlur={(e) => handleBlur(e, field.onBlur)}
+                  onBlur={handleBlur}
                   inputMode={inputType === 'date' ? 'decimal' : 'text'}
                 />
                 {isFocused && field.value && !disabled && (
@@ -179,7 +179,7 @@ const JoinInput = <T extends FieldValues>({
                     ref={resetButtonRef}
                     onMouseDown={(e) => {
                       e.preventDefault(); // blur 방지
-                      handleReset(field.onChange);
+                      handleReset();
                     }}
                   >
                     <Icon icon="CloseRound" width={22} height={22} cursor="pointer" />

--- a/src/app/join/components/JoinInput/JoinInput.tsx
+++ b/src/app/join/components/JoinInput/JoinInput.tsx
@@ -16,38 +16,9 @@ import {
   inputLabel,
   infoContainer,
 } from './JoinInput.css';
-import { formatBirthdate, formatDateInput } from './JoinInput.utils';
+import { formatDateInput, getBackspaceAfterDotResult } from './JoinInput.utils';
 
 import Icon from '@/components/Icon';
-
-// 온점 뒤 백스페이스 처리 함수
-const getBackspaceAfterDotResult = (
-  previousValue: string,
-  currentValue: string,
-  previousCursor: number | null,
-) => {
-  if (!previousValue || currentValue.length >= previousValue.length) {
-    return null;
-  }
-
-  // 온점 뒤에서 발생한 백스페이스 입력한 경우
-  if (previousCursor && previousValue[previousCursor - 1] === '.') {
-    const numbers = previousValue.replace(/\D/g, '');
-    const digitsBeforeDot = previousValue.slice(0, previousCursor - 1).replace(/\D/g, '').length;
-
-    if (digitsBeforeDot > 0) {
-      // 온점 바로 앞 숫자 제거
-      const newNumbers = numbers.slice(0, digitsBeforeDot - 1) + numbers.slice(digitsBeforeDot);
-
-      const formattedValue = formatBirthdate(newNumbers);
-      const cursorPosition = formatBirthdate(newNumbers.slice(0, digitsBeforeDot - 1)).length;
-
-      return { newValue: formattedValue, newCursor: cursorPosition };
-    }
-  }
-
-  return null;
-};
 
 interface JoinInputProps<T extends FieldValues> {
   name: Path<T>;

--- a/src/app/join/components/JoinInput/JoinInput.tsx
+++ b/src/app/join/components/JoinInput/JoinInput.tsx
@@ -16,118 +16,31 @@ import {
   inputLabel,
   infoContainer,
 } from './JoinInput.css';
+import { formatDateInput } from './JoinInput.utils';
 
 import Icon from '@/components/Icon';
 
-const formatDateInput = (
-  inputType: string,
-  value: string,
-  selectionStart: number | null = null,
+// 온점 뒤 백스페이스 처리 함수
+const handleSpecialBackspace = (
+  previousValue: string,
+  currentValue: string,
+  previousCursor: number | null,
 ) => {
-  if (inputType !== 'date') {
-    return { formattedValue: value, cursorPosition: selectionStart ?? value.length };
-  }
-
-  // 숫자만 추출
-  const numbers = value.replace(/\D/g, '');
-
-  // 최대 8자리까지만 허용 (YYYYMMDD)
-  const limitedNumbers = numbers.slice(0, 8);
-
-  let formattedValue = '';
-  let cursorPosition = selectionStart ?? value.length;
-
-  // 포맷팅 적용
-  if (limitedNumbers.length <= 4) {
-    // YYYY
-    formattedValue = limitedNumbers;
-  } else if (limitedNumbers.length <= 6) {
-    // YYYY.MM
-    const year = limitedNumbers.slice(0, 4);
-    const month = limitedNumbers.slice(4);
-    formattedValue = `${year}.${month}`;
-  } else {
-    // YYYY.MM.DD
-    const year = limitedNumbers.slice(0, 4);
-    const month = limitedNumbers.slice(4, 6);
-    const day = limitedNumbers.slice(6);
-    formattedValue = `${year}.${month}.${day}`;
-  }
-
-  // 커서 위치 계산
-  if (selectionStart !== null) {
-    // 현재 커서 위치까지의 숫자 개수 계산
-    const numbersBeforeCursor = value.slice(0, selectionStart).replace(/\D/g, '').length;
-
-    // 새로운 포맷된 값에서 해당 숫자 위치 찾기
-    let newCursorPosition = 0;
-    let numberCount = 0;
-
-    for (let i = 0; i < formattedValue.length; i++) {
-      if (/\d/.test(formattedValue[i])) {
-        numberCount++;
-        if (numberCount === numbersBeforeCursor) {
-          newCursorPosition = i + 1;
-          break;
-        }
-      }
-      if (numberCount < numbersBeforeCursor) {
-        newCursorPosition = i + 1;
-      }
-    }
-
-    // 만약 모든 숫자를 다 센 경우, 마지막 위치로
-    if (numberCount < numbersBeforeCursor) {
-      newCursorPosition = formattedValue.length;
-    }
-
-    cursorPosition = newCursorPosition;
-  } else {
-    cursorPosition = formattedValue.length;
-  }
-
-  return { formattedValue, cursorPosition };
-};
-
-const handleDateBackspace = (
-  value: string,
-  selectionStart: number | null,
-  selectionEnd: number | null,
-): { newValue: string; newCursorPosition: number } | null => {
-  // 날짜 입력이 아니거나 커서 위치가 없으면 기본 동작
-  if (!selectionStart || selectionStart !== selectionEnd) {
+  // 값이 줄어들지 않았으면 백스페이스가 아님
+  if (!previousValue || currentValue.length >= previousValue.length) {
     return null;
   }
 
-  // 온점 바로 뒤에 커서가 있는지 확인
-  const charBeforeCursor = value[selectionStart - 1];
-  if (charBeforeCursor !== '.') {
-    return null;
-  }
-
-  // 온점 앞의 숫자를 찾아서 삭제
-  let newValue = value;
-  const deletePosition = selectionStart - 2; // 온점 앞 위치
-
-  // 온점 앞에 숫자가 있는지 확인하고 삭제
-  if (deletePosition >= 0 && /\d/.test(newValue[deletePosition])) {
-    newValue = newValue.slice(0, deletePosition) + newValue.slice(deletePosition + 1);
-
-    // 삭제 후 포맷팅 적용
-    const { formattedValue } = formatDateInput('date', newValue, deletePosition);
-
-    // 새로운 커서 위치 계산 (삭제된 숫자 위치)
-    let newCursorPosition = deletePosition;
-
-    // 포맷팅으로 인해 온점이 사라졌을 수 있으므로 조정
-    if (formattedValue.length < value.length - 1) {
-      // 온점이 사라진 경우, 커서를 해당 위치로
-      newCursorPosition = Math.min(deletePosition, formattedValue.length);
+  // 온점 뒤에서 백스페이스 감지
+  if (previousCursor && previousValue[previousCursor - 1] === '.') {
+    const deletePos = previousCursor - 2;
+    if (deletePos >= 0 && /\d/.test(previousValue[deletePos])) {
+      // 온점 앞 숫자 삭제
+      const newValue = previousValue.slice(0, deletePos) + previousValue.slice(deletePos + 1);
+      const { formattedValue } = formatDateInput('date', newValue, deletePos);
+      return { newValue: formattedValue, newCursor: deletePos };
     }
-
-    return { newValue: formattedValue, newCursorPosition };
   }
-
   return null;
 };
 
@@ -174,6 +87,10 @@ const JoinInput = <T extends FieldValues>({
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [pendingCursorPosition, setPendingCursorPosition] = useState<number | null>(null);
 
+  // 백스페이스 감지를 위한 이전 상태 추적
+  const previousValueRef = useRef('');
+  const previousCursorRef = useRef<number | null>(null);
+
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>, onBlur: () => void) => {
     if (resetButtonRef.current && resetButtonRef.current.contains(e.relatedTarget)) {
       return;
@@ -208,105 +125,118 @@ const JoinInput = <T extends FieldValues>({
         control={control}
         rules={rules}
         defaultValue={value}
-        render={({ field, fieldState }) => (
-          <>
-            <div className={inputWrapper}>
-              <input
-                {...field}
-                id={name}
-                ref={(el) => {
-                  field.ref(el);
-                  inputRef.current = el;
-                  if (typeof inputPropRef === 'function') {
-                    inputPropRef(el);
-                  } else if (inputPropRef) {
-                    inputPropRef.current = el;
-                  }
-                }}
-                placeholder={placeholder}
-                disabled={disabled}
-                maxLength={maxLength}
-                aria-invalid={fieldState.invalid ? true : false}
-                style={{ width: '100%' }}
-                className={`${joinInput} ${className ?? ''}`}
-                onChange={(e) => {
-                  const { formattedValue, cursorPosition } = formatDateInput(
-                    inputType,
-                    e.target.value,
-                    e.target.selectionStart,
-                  );
-                  field.onChange(formattedValue);
+        render={({ field, fieldState }) => {
+          const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (inputType === 'date') {
+              previousValueRef.current = field.value || '';
+              previousCursorRef.current = e.currentTarget.selectionStart;
+            }
 
-                  // 커서 위치 복원 (useLayoutEffect를 통해)
-                  if (inputType === 'date') {
-                    setPendingCursorPosition(cursorPosition);
-                  }
-                }}
-                onFocus={() => setIsFocused(true)}
-                onBlur={(e) => handleBlur(e, field.onBlur)}
-                onKeyDown={(e) => {
-                  // 날짜 입력에서 백스페이스 특별 처리
-                  if (inputType === 'date' && e.key === 'Backspace') {
-                    const result = handleDateBackspace(
-                      field.value || '',
-                      e.currentTarget.selectionStart,
-                      e.currentTarget.selectionEnd,
-                    );
+            onKeyDown?.(e);
+          };
 
-                    if (result) {
-                      e.preventDefault();
-                      field.onChange(result.newValue);
+          const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+            const currentValue = e.target.value;
+            const currentCursor = e.target.selectionStart;
 
-                      // 커서 위치 복원 (useLayoutEffect를 통해)
-                      setPendingCursorPosition(result.newCursorPosition);
-                      return;
+            if (inputType === 'date') {
+              const backspaceResult = handleSpecialBackspace(
+                previousValueRef.current,
+                currentValue,
+                previousCursorRef.current,
+              );
+
+              if (backspaceResult) {
+                field.onChange(backspaceResult.newValue);
+                setPendingCursorPosition(backspaceResult.newCursor);
+                previousValueRef.current = backspaceResult.newValue;
+                previousCursorRef.current = backspaceResult.newCursor;
+                return;
+              }
+            }
+
+            // 일반적인 포맷팅 처리
+            const { formattedValue, cursorPosition } = formatDateInput(
+              inputType,
+              currentValue,
+              currentCursor,
+            );
+            field.onChange(formattedValue);
+
+            if (inputType === 'date') {
+              setPendingCursorPosition(cursorPosition);
+              previousValueRef.current = formattedValue;
+              previousCursorRef.current = cursorPosition;
+            }
+          };
+
+          return (
+            <>
+              <div className={inputWrapper}>
+                <input
+                  {...field}
+                  id={name}
+                  ref={(el) => {
+                    field.ref(el);
+                    inputRef.current = el;
+                    if (typeof inputPropRef === 'function') {
+                      inputPropRef(el);
+                    } else if (inputPropRef) {
+                      inputPropRef.current = el;
                     }
-                  }
-
-                  // 기존 onKeyDown 핸들러 호출
-                  onKeyDown?.(e);
-                }}
-                inputMode={inputType === 'date' ? 'decimal' : 'text'}
-              />
-              {isFocused && field.value && !disabled && (
-                <button
-                  className={inputResetButton}
-                  ref={resetButtonRef}
-                  onMouseDown={(e) => {
-                    e.preventDefault(); // blur 방지
-                    handleReset(field.onChange);
                   }}
-                >
-                  <Icon icon="CloseRound" width={22} height={22} cursor="pointer" />
-                </button>
-              )}
-            </div>
-            <div className={infoContainer}>
-              {/* 왼쪽: 에러 메시지 또는 헬퍼 텍스트 */}
-              <div>
-                {fieldState.error ? (
-                  <span className={errorMessage}>{fieldState.error.message}</span>
-                ) : (
-                  tip && (
-                    <div className={tipWrapper}>
-                      {isTip && <span className={tipAlert}>Tip</span>}
-                      <span>{tip}</span>
-                    </div>
-                  )
+                  placeholder={placeholder}
+                  disabled={disabled}
+                  maxLength={maxLength}
+                  aria-invalid={fieldState.invalid ? true : false}
+                  style={{ width: '100%' }}
+                  className={`${joinInput} ${className ?? ''}`}
+                  onChange={handleChange}
+                  onKeyDown={handleKeyDown}
+                  onFocus={() => setIsFocused(true)}
+                  onBlur={(e) => handleBlur(e, field.onBlur)}
+                  inputMode={inputType === 'date' ? 'decimal' : 'text'}
+                />
+                {isFocused && field.value && !disabled && (
+                  <button
+                    className={inputResetButton}
+                    ref={resetButtonRef}
+                    onMouseDown={(e) => {
+                      e.preventDefault(); // blur 방지
+                      handleReset(field.onChange);
+                    }}
+                  >
+                    <Icon icon="CloseRound" width={22} height={22} cursor="pointer" />
+                  </button>
                 )}
               </div>
+              <div className={infoContainer}>
+                {/* 왼쪽: 에러 메시지 또는 헬퍼 텍스트 */}
+                <div>
+                  {fieldState.error ? (
+                    <span className={errorMessage}>{fieldState.error.message}</span>
+                  ) : (
+                    tip && (
+                      <div className={tipWrapper}>
+                        {isTip && <span className={tipAlert}>Tip</span>}
+                        <span>{tip}</span>
+                      </div>
+                    )
+                  )}
+                </div>
 
-              {/* 오른쪽: 카운트 */}
-              <div>
-                {maxLength && (
-                  <span className={textCount}>
-                    {field.value?.length || 0}/{maxLength}
-                  </span>
-                )}
+                {/* 오른쪽: 카운트 */}
+                <div>
+                  {maxLength && (
+                    <span className={textCount}>
+                      {field.value?.length || 0}/{maxLength}
+                    </span>
+                  )}
+                </div>
               </div>
-            </div>
-          </>
-        )}
+            </>
+          );
+        }}
       />
     </div>
   );

--- a/src/app/join/components/JoinInput/JoinInput.tsx
+++ b/src/app/join/components/JoinInput/JoinInput.tsx
@@ -16,31 +16,36 @@ import {
   inputLabel,
   infoContainer,
 } from './JoinInput.css';
-import { formatDateInput } from './JoinInput.utils';
+import { formatBirthdate, formatDateInput } from './JoinInput.utils';
 
 import Icon from '@/components/Icon';
 
 // 온점 뒤 백스페이스 처리 함수
-const handleSpecialBackspace = (
+const getBackspaceAfterDotResult = (
   previousValue: string,
   currentValue: string,
   previousCursor: number | null,
 ) => {
-  // 값이 줄어들지 않았으면 백스페이스가 아님
   if (!previousValue || currentValue.length >= previousValue.length) {
     return null;
   }
 
-  // 온점 뒤에서 백스페이스 감지
+  // 온점 뒤에서 발생한 백스페이스 입력한 경우
   if (previousCursor && previousValue[previousCursor - 1] === '.') {
-    const deletePos = previousCursor - 2;
-    if (deletePos >= 0 && /\d/.test(previousValue[deletePos])) {
-      // 온점 앞 숫자 삭제
-      const newValue = previousValue.slice(0, deletePos) + previousValue.slice(deletePos + 1);
-      const { formattedValue } = formatDateInput('date', newValue, deletePos);
-      return { newValue: formattedValue, newCursor: deletePos };
+    const numbers = previousValue.replace(/\D/g, '');
+    const digitsBeforeDot = previousValue.slice(0, previousCursor - 1).replace(/\D/g, '').length;
+
+    if (digitsBeforeDot > 0) {
+      // 온점 바로 앞 숫자 제거
+      const newNumbers = numbers.slice(0, digitsBeforeDot - 1) + numbers.slice(digitsBeforeDot);
+
+      const formattedValue = formatBirthdate(newNumbers);
+      const cursorPosition = formatBirthdate(newNumbers.slice(0, digitsBeforeDot - 1)).length;
+
+      return { newValue: formattedValue, newCursor: cursorPosition };
     }
   }
+
   return null;
 };
 
@@ -140,7 +145,7 @@ const JoinInput = <T extends FieldValues>({
             const currentCursor = e.target.selectionStart;
 
             if (inputType === 'date') {
-              const backspaceResult = handleSpecialBackspace(
+              const backspaceResult = getBackspaceAfterDotResult(
                 previousValueRef.current,
                 currentValue,
                 previousCursorRef.current,

--- a/src/app/join/components/JoinInput/JoinInput.tsx
+++ b/src/app/join/components/JoinInput/JoinInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState, useLayoutEffect } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { Control, Controller, FieldValues, Path, PathValue } from 'react-hook-form';
 
 import {
@@ -187,8 +187,8 @@ const JoinInput = <T extends FieldValues>({
     inputRef.current?.focus();
   };
 
-  // 커서 위치 복원을 위한 useLayoutEffect
-  useLayoutEffect(() => {
+  // '.' 을 지웠을 때 커서 위치 조정을 위한 useEffect
+  useEffect(() => {
     if (pendingCursorPosition !== null && inputRef.current?.setSelectionRange) {
       inputRef.current.setSelectionRange(pendingCursorPosition, pendingCursorPosition);
       setPendingCursorPosition(null);

--- a/src/app/join/components/JoinInput/JoinInput.tsx
+++ b/src/app/join/components/JoinInput/JoinInput.tsx
@@ -141,6 +141,7 @@ const JoinInput = <T extends FieldValues>({
                 onFocus={() => setIsFocused(true)}
                 onBlur={(e) => handleBlur(e, field.onBlur)}
                 onKeyDown={onKeyDown}
+                inputMode={inputType === 'date' ? 'decimal' : 'text'}
               />
               {isFocused && field.value && !disabled && (
                 <button

--- a/src/app/join/components/JoinInput/JoinInput.utils.ts
+++ b/src/app/join/components/JoinInput/JoinInput.utils.ts
@@ -1,0 +1,28 @@
+export const formatBirthdate = (date: string) => {
+  if (date.length <= 4) return date;
+  if (date.length <= 6) return `${date.slice(0, 4)}.${date.slice(4)}`;
+  return `${date.slice(0, 4)}.${date.slice(4, 6)}.${date.slice(6)}`;
+};
+
+export const formatDateInput = (
+  inputType: 'text' | 'date',
+  value: string,
+  cursorPos: number | null = null,
+) => {
+  if (inputType !== 'date') {
+    return { formattedValue: value, cursorPosition: cursorPos ?? value.length };
+  }
+
+  const BIRTHDATE_MAX_LENGTH = 8;
+  const numbers = value.replace(/\D/g, '').slice(0, BIRTHDATE_MAX_LENGTH);
+
+  // YYYY.MM.DD
+  const formattedValue = formatBirthdate(numbers);
+
+  // 커서 위치 계산
+  const cursorPosition = cursorPos
+    ? formatBirthdate(value.slice(0, cursorPos).replace(/\D/g, '')).length
+    : formattedValue.length;
+
+  return { formattedValue, cursorPosition };
+};

--- a/src/app/join/components/JoinInput/JoinInput.utils.ts
+++ b/src/app/join/components/JoinInput/JoinInput.utils.ts
@@ -1,9 +1,43 @@
-export const formatBirthdate = (date: string) => {
+const formatBirthdate = (date: string) => {
   if (date.length <= 4) return date;
   if (date.length <= 6) return `${date.slice(0, 4)}.${date.slice(4)}`;
   return `${date.slice(0, 4)}.${date.slice(4, 6)}.${date.slice(6)}`;
 };
 
+/**
+ *  @description 온점 뒤에서 백스페이스 입력 시 처리 함수
+ */
+export const getBackspaceAfterDotResult = (
+  previousValue: string,
+  currentValue: string,
+  previousCursor: number | null,
+) => {
+  if (!previousValue || currentValue.length >= previousValue.length) {
+    return null;
+  }
+
+  // 온점 뒤에서 발생한 백스페이스 입력한 경우
+  if (previousCursor && previousValue[previousCursor - 1] === '.') {
+    const numbers = previousValue.replace(/\D/g, '');
+    const digitsBeforeDot = previousValue.slice(0, previousCursor - 1).replace(/\D/g, '').length;
+
+    if (digitsBeforeDot > 0) {
+      // 온점 바로 앞 숫자 제거
+      const newNumbers = numbers.slice(0, digitsBeforeDot - 1) + numbers.slice(digitsBeforeDot);
+
+      const formattedValue = formatBirthdate(newNumbers);
+      const cursorPosition = formatBirthdate(newNumbers.slice(0, digitsBeforeDot - 1)).length;
+
+      return { newValue: formattedValue, newCursor: cursorPosition };
+    }
+  }
+
+  return null;
+};
+
+/**
+ *  @description 생년월일 포맷팅 및 커서 위치 반환 함수
+ */
 export const formatDateInput = (
   inputType: 'text' | 'date',
   value: string,

--- a/src/app/join/desktop/Participant/JoinInfoStep/JoinInfoStep.tsx
+++ b/src/app/join/desktop/Participant/JoinInfoStep/JoinInfoStep.tsx
@@ -79,7 +79,7 @@ const JoinInfoStep = ({ handleSubmit }: JoinInfoStepProps) => {
           control={control}
           label="생년월일"
           required
-          placeholder="YYYY.MM.DD"
+          placeholder="YYYY. MM. DD"
           tip="나중에 수정할 수 없어요"
           isTip={false}
           inputType="date"

--- a/src/app/join/mobile/Participant/JoinInfoStep/JoinInfoStep.tsx
+++ b/src/app/join/mobile/Participant/JoinInfoStep/JoinInfoStep.tsx
@@ -63,6 +63,7 @@ const JoinInfoStep = ({ onNext }: JoinInfoStepProps) => {
           required
           inputPropRef={setInputRef('birthDate')}
           onKeyDown={handleKeyDown('birthDate')}
+          inputType="date"
         />
 
         {/* 성별 */}


### PR DESCRIPTION
## Issue Number
<!-- #이슈번호 -->
closed #248 

## As-Is
<!-- 문제 상황 정의 -->
- 생년월일을 입력할 때 온점('.;)을 직접 입력해야 해서 불편하다.
- 사용자가 잘못 입력할 가능성이 높다.

## To-Be
<!-- 변경 사항 -->
- 생년월일 입력 시 숫자 키패드만 올라온다.
- 생년월일 입력 시 온점('.')이 자동으로 찍힌다.
- 커서를 앞으로 이동하고 입력해도 문제 없이 동작한다.

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

| AS-IS | TO-BE |
|:-:|:-:|
|<video src="https://github.com/user-attachments/assets/87da0836-0de1-496c-ba7e-53ae7a9e9f97" />|<video src="https://github.com/user-attachments/assets/e600e3cf-7471-4f39-ab5f-ecfb207ccb7a" />|


## (Optional) Additional Description

### 생년월일 온점 자동 입력

생년월일을 입력할 때 온점이 자동으로 입력되도록 처리하여 사용자 경험을 개선했어요.
이전에 구현했던 로직은 단순히 잘라서 온점을 주입하기만 해서 예외 케이스에 대한 대응이 되지 않았어요. 예를 들어, 앞의 숫자가 틀려서 커서를 앞으로 이동하여 제거할 경우 숫자가 망가지는 현상이 발생했었어요. 이를 막기 위해 여러 로직이 필요했어요.

단순하게는 `년도.월.일` 을 4개, 2개, 2개마다 구분점을 찍어서 반환하면 되는 기능입니다.
다만 사용자는 숫자만 입력할 수 있도록 하고, 온점은 알아서 찍히도록 처리하는 게 어려웠어요. 특히, 커서의 위치와 온점 뒤에서 백스페이스를 눌렀을 때의 처리가 복잡했어요.

커서의 현재 위치는 e.target.selectionStart로 인덱스를 알 수 있었어요. changeEvent와 keyboardEvent에 존재하는데, 커서의 현재 위치와 현재값 기준으로 계산해요.

예를 들어 `"1234.56.78"`을 입력했어요. 6 뒤에 커서를 두고 6을 지운다면 `1234.5|7.8`이 되어야해요. 그러기 위해선 cursorPosition가 6이 되어야합니다.  cursorPos는 기존의 6이 있었던 자리의 인덱스인 6이고, `formatBirthdate(value.slice(0, cursorPos).replace(/\D/g, '')).length` 를 계산하면 "1234.5".length 이므로 6이 반환됩니다.

```ts
const formatBirthdate = (date: string) => {
  if (date.length <= 4) return date;
  if (date.length <= 6) return `${date.slice(0, 4)}.${date.slice(4)}`;
  return `${date.slice(0, 4)}.${date.slice(4, 6)}.${date.slice(6)}`;
};

export const formatDateInput = (
  inputType: 'text' | 'date',
  value: string,
  cursorPos: number | null = null,
) => {
  if (inputType !== 'date') {
    return { formattedValue: value, cursorPosition: cursorPos ?? value.length };
  }

  const BIRTHDATE_MAX_LENGTH = 8;
  const numbers = value.replace(/\D/g, '').slice(0, BIRTHDATE_MAX_LENGTH);

  // YYYY.MM.DD
  const formattedValue = formatBirthdate(numbers);

  // 커서 위치 계산
  const cursorPosition = cursorPos
    ? formatBirthdate(value.slice(0, cursorPos).replace(/\D/g, '')).length
    : formattedValue.length;

  return { formattedValue, cursorPosition };
};
```

### 온점 뒤에서 백스페이스를 할 경우

위의 함수에서 예외 상황이 있어요. `"1234.56.78"`에서 온점 뒤에 커서를 두고(`"1234.56.|78"`) 백스페이스를 누르면 입력값은 변하지 않고 커서만 이동해요(`"1234.56|.78"`).
이유는 방금처럼 온점에 두고 백스페이스를 누르면 value에 1234.5678이 들어오는데 이를 포맷팅하면 다시 1234.56.78이 돼서 값이 변화가 없는거고, 커서 위치만 재계산되니까 커서 위치만 변경된걸로 보이게 돼요. 따라서 온점 뒤에서 백스페이스를 했을 때는 **온점 앞의 숫자가 지워지고 커서도 따라서 이동하는 게 자연스럽다고 생각했어요.**

```ts
export const getBackspaceAfterDotResult = (
  previousValue: string,
  currentValue: string,
  previousCursor: number | null,
) => {
  if (!previousValue || currentValue.length >= previousValue.length) {
    return null;
  }

  // 온점 뒤에서 발생한 백스페이스 입력한 경우
  if (previousCursor && previousValue[previousCursor - 1] === '.') {
    const numbers = previousValue.replace(/\D/g, '');
    const digitsBeforeDot = previousValue.slice(0, previousCursor - 1).replace(/\D/g, '').length;

    if (digitsBeforeDot > 0) {
      // 온점 바로 앞 숫자 제거
      const newNumbers = numbers.slice(0, digitsBeforeDot - 1) + numbers.slice(digitsBeforeDot);

      const formattedValue = formatBirthdate(newNumbers);
      const cursorPosition = formatBirthdate(newNumbers.slice(0, digitsBeforeDot - 1)).length;

      return { newValue: formattedValue, newCursor: cursorPosition };
    }
  }

  return null;
};
```