### PR TITLE
[YS-564] 모바일 mixpanel 트래킹 이벤트 추가 및 copy 이벤트 세분화

### DIFF
--- a/src/app/post/[postId]/desktop/components/ExperimentPostOutline/ExperimentPostOutline.tsx
+++ b/src/app/post/[postId]/desktop/components/ExperimentPostOutline/ExperimentPostOutline.tsx
@@ -135,6 +135,7 @@ const ExperimentPostOutline = ({ postDetailData, applyMethodData }: ExperimentPo
             onClick={() => {
               trackEvent('ApplyMethod Interaction', {
                 action: 'Click ApplyMethod Modal',
+                device: 'desktop',
               });
               setIsModalOpen(true);
             }}

--- a/src/app/post/[postId]/desktop/components/ParticipationGuideModal/ParticipationGuideModal.tsx
+++ b/src/app/post/[postId]/desktop/components/ParticipationGuideModal/ParticipationGuideModal.tsx
@@ -32,13 +32,13 @@ const ParticipationGuideModal = ({
 }: ParticipationGuideModalProps) => {
   const toast = useToast();
 
-  const handleCopyContent = (text: string) => {
+  const handleCopyContent = (text: string, type: 'link' | 'contactInfo') => {
     navigator.clipboard
       .writeText(text)
       .then(() => {
         toast.open({ message: '복사되었어요', duration: 1500 });
         trackEvent('ApplyMethod Interaction', {
-          action: 'Link Copied',
+          action: type === 'link' ? 'Link Copied' : 'ContactInfo Copied',
         });
       })
       .catch(() => {
@@ -108,7 +108,8 @@ const ParticipationGuideModal = ({
                       height={16}
                       cursor="pointer"
                       onClick={() =>
-                        applyMethodData.formUrl && handleCopyContent(applyMethodData.formUrl)
+                        applyMethodData.formUrl &&
+                        handleCopyContent(applyMethodData.formUrl, 'link')
                       }
                     />
                   </div>
@@ -127,7 +128,8 @@ const ParticipationGuideModal = ({
                       height={16}
                       cursor="pointer"
                       onClick={() =>
-                        applyMethodData.phoneNum && handleCopyContent(applyMethodData.phoneNum)
+                        applyMethodData.phoneNum &&
+                        handleCopyContent(applyMethodData.phoneNum, 'contactInfo')
                       }
                     />
                   </div>

--- a/src/app/post/[postId]/mobile/components/ExperimentPostMobileContentWrapper/ExperimentPostMobileContentWrapper.tsx
+++ b/src/app/post/[postId]/mobile/components/ExperimentPostMobileContentWrapper/ExperimentPostMobileContentWrapper.tsx
@@ -13,6 +13,7 @@ import ParticipationGuideBottomSheet from '../ParticipationGuideBottomSheet/Part
 
 import Button from '@/components/Button/Button';
 import useOverlay from '@/hooks/useOverlay';
+import { trackEvent } from '@/lib/mixpanelClient';
 
 const ExperimentPostMobileContentWrapper = ({
   postDetailData,
@@ -24,6 +25,11 @@ const ExperimentPostMobileContentWrapper = ({
   const { open, close } = useOverlay();
 
   const handleOpenBottomSheet = () => {
+    trackEvent('ApplyMethod Interaction', {
+      action: 'Click ApplyMethod Modal',
+      device: 'mobile',
+    });
+
     open(
       () => <ParticipationGuideBottomSheet onConfirm={close} applyMethodData={applyMethodData} />,
       {

--- a/src/app/post/[postId]/mobile/components/ParticipationGuideBottomSheet/ParticipationGuideBottomSheet.tsx
+++ b/src/app/post/[postId]/mobile/components/ParticipationGuideBottomSheet/ParticipationGuideBottomSheet.tsx
@@ -20,13 +20,14 @@ const ParticipationGuideBottomSheet = ({
   applyMethodData,
 }: ParticipationGuideBottomSheetProps) => {
   const toast = useToast();
-  const handleCopyContent = (text: string) => {
+  const handleCopyContent = (text: string, type: 'link' | 'contactInfo') => {
     navigator.clipboard
       .writeText(text)
       .then(() => {
         toast.open({ message: '복사되었어요' });
+
         trackEvent('ApplyMethod Interaction', {
-          action: 'Link Copied',
+          action: type === 'link' ? 'Link Copied' : 'ContactInfo Copied',
         });
       })
       .catch(() => {
@@ -79,7 +80,7 @@ const ParticipationGuideBottomSheet = ({
                 cursor="pointer"
                 color={colors.text04}
                 onClick={() =>
-                  applyMethodData.formUrl && handleCopyContent(applyMethodData.formUrl)
+                  applyMethodData.formUrl && handleCopyContent(applyMethodData.formUrl, 'link')
                 }
               />
             </div>
@@ -99,7 +100,8 @@ const ParticipationGuideBottomSheet = ({
                 cursor="pointer"
                 color={colors.text04}
                 onClick={() =>
-                  applyMethodData.phoneNum && handleCopyContent(applyMethodData.phoneNum)
+                  applyMethodData.phoneNum &&
+                  handleCopyContent(applyMethodData.phoneNum, 'contactInfo')
                 }
               />
             </div>


### PR DESCRIPTION
## Issue Number
close #253 
<!-- #이슈번호 -->

## As-Is
- 사용자 트래킹을 위해 믹스패널 트래킹 이벤트를 도입했으나,
"참여방법 확인하기" 버튼 클릭을 조회하는 이벤트가 모바일엔 적용되지 않고 있었음.

- 링크 및 연락처 복사 시 "Link Copied"로 동일하게 트래킹되고 있음.

<!-- 문제 상황 정의 -->


## To-Be
<!-- 변경 사항 -->


- "참여방법 확인하기" 버튼 클릭 조회 이벤트 모바일 추가
- 링크 및 연락처 복사하기 트래킹 이벤트를 각각 "Link Copied" / "ContactInfo Copied"로 세분화


## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
빠르게 반영되어야 할 것 같아서 바로 머지 및 배포하겠습니다!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Chores**
  * 사용자 상호작용 추적 기능을 개선했습니다.
  * 콘텐츠 복사 기능에서 링크와 연락처 정보 복사를 구분하여 추적합니다.
  * 데스크톱 및 모바일 환경에서의 사용자 액션 추적을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->